### PR TITLE
fix: `DuplicatedTypeName` exception thrown in v4.5.5

### DIFF
--- a/.devcontainer/Dockerfile-plugin_dev
+++ b/.devcontainer/Dockerfile-plugin_dev
@@ -1,4 +1,4 @@
-ARG NETBOX_VARIANT=v4.5.3-4.0.0
+ARG NETBOX_VARIANT=v4.5.5-4.0.2
 
 FROM ghcr.io/netbox-community/netbox:${NETBOX_VARIANT}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install NetBox
         run: |
           # Clone NetBox
-          git clone --depth 1 --branch v4.5.2 https://github.com/netbox-community/netbox.git /tmp/netbox
+          git clone --depth 1 --branch v4.5.5 https://github.com/netbox-community/netbox.git /tmp/netbox
 
           # Install NetBox dependencies
           pip install --upgrade pip

--- a/notices/__init__.py
+++ b/notices/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Jonathan Senecal"""
 __email__ = "contact@jonathansenecal.com"
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 
 from netbox.plugins import PluginConfig

--- a/notices/graphql/filters.py
+++ b/notices/graphql/filters.py
@@ -1,7 +1,7 @@
 import strawberry_django
 from netbox.graphql.filters import PrimaryModelFilter
 from strawberry.scalars import ID
-from strawberry_django import FilterLookup
+from strawberry_django import StrFilterLookup
 
 from notices import models
 
@@ -17,43 +17,43 @@ __all__ = (
 
 @strawberry_django.filter_type(models.Maintenance, lookups=True)
 class MaintenanceFilter(PrimaryModelFilter):
-    name: FilterLookup[str] | None = strawberry_django.filter_field()
-    summary: FilterLookup[str] | None = strawberry_django.filter_field()
-    status: FilterLookup[str] | None = strawberry_django.filter_field()
+    name: StrFilterLookup | None = strawberry_django.filter_field()
+    summary: StrFilterLookup | None = strawberry_django.filter_field()
+    status: StrFilterLookup | None = strawberry_django.filter_field()
     provider_id: ID | None = strawberry_django.filter_field()
     acknowledged: bool | None = strawberry_django.filter_field()
 
 
 @strawberry_django.filter_type(models.Outage, lookups=True)
 class OutageFilter(PrimaryModelFilter):
-    name: FilterLookup[str] | None = strawberry_django.filter_field()
-    summary: FilterLookup[str] | None = strawberry_django.filter_field()
-    status: FilterLookup[str] | None = strawberry_django.filter_field()
+    name: StrFilterLookup | None = strawberry_django.filter_field()
+    summary: StrFilterLookup | None = strawberry_django.filter_field()
+    status: StrFilterLookup | None = strawberry_django.filter_field()
     provider_id: ID | None = strawberry_django.filter_field()
     acknowledged: bool | None = strawberry_django.filter_field()
 
 
 @strawberry_django.filter_type(models.Impact, lookups=True)
 class ImpactFilter(PrimaryModelFilter):
-    impact: FilterLookup[str] | None = strawberry_django.filter_field()
+    impact: StrFilterLookup | None = strawberry_django.filter_field()
     event_object_id: ID | None = strawberry_django.filter_field()
     target_object_id: ID | None = strawberry_django.filter_field()
 
 
 @strawberry_django.filter_type(models.EventNotification, lookups=True)
 class EventNotificationFilter(PrimaryModelFilter):
-    subject: FilterLookup[str] | None = strawberry_django.filter_field()
-    email_from: FilterLookup[str] | None = strawberry_django.filter_field()
+    subject: StrFilterLookup | None = strawberry_django.filter_field()
+    email_from: StrFilterLookup | None = strawberry_django.filter_field()
 
 
 @strawberry_django.filter_type(models.NotificationTemplate, lookups=True)
 class NotificationTemplateFilter(PrimaryModelFilter):
-    name: FilterLookup[str] | None = strawberry_django.filter_field()
-    slug: FilterLookup[str] | None = strawberry_django.filter_field()
-    event_type: FilterLookup[str] | None = strawberry_django.filter_field()
+    name: StrFilterLookup | None = strawberry_django.filter_field()
+    slug: StrFilterLookup | None = strawberry_django.filter_field()
+    event_type: StrFilterLookup | None = strawberry_django.filter_field()
 
 
 @strawberry_django.filter_type(models.PreparedNotification, lookups=True)
 class PreparedNotificationFilter(PrimaryModelFilter):
-    status: FilterLookup[str] | None = strawberry_django.filter_field()
-    subject: FilterLookup[str] | None = strawberry_django.filter_field()
+    status: StrFilterLookup | None = strawberry_django.filter_field()
+    subject: StrFilterLookup | None = strawberry_django.filter_field()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,45 +13,43 @@ notices = ["templates/**/*", "static/**/*"]
 [project]
 name = "netbox-notices"
 keywords = ['notices']
-version = "1.1.1"
+version = "1.1.2"
 description = "Track maintenance and outage events across various NetBox models from vendors and internal sources."
 readme = "README.md"
 authors = [
-    { name = "Jonathan Senecal", email = "contact@jonathansenecal.com" },
-    { name = "Jason Yates", email = "me@jasonyates.co.uk" }
+  { name = "Jonathan Senecal", email = "contact@jonathansenecal.com" },
+  { name = "Jason Yates", email = "me@jasonyates.co.uk" },
 ]
 license-files = ["LICENSE"]
 
 classifiers = [
-    'Development Status :: 4 - Beta',
-    'Intended Audience :: Developers',
-    'Natural Language :: English',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.12',
-    'Programming Language :: Python :: 3.13',
+  'Development Status :: 4 - Beta',
+  'Intended Audience :: Developers',
+  'Natural Language :: English',
+  'Programming Language :: Python :: 3',
+  'Programming Language :: Python :: 3.12',
+  'Programming Language :: Python :: 3.13',
 ]
 
 requires-python = ">=3.12.0"
 
-dependencies = [
-    "icalendar>=5.0.0",
-]
+dependencies = ["icalendar>=5.0.0"]
 
 [project.optional-dependencies]
 dev = [
-    "black==25.1.0",
-    "bumpver",
-    "isort==6.0.1",
-    "pip-tools",
-    "pre-commit>=4.0.0",
-    "pytest",
-    "pytest-django>=4.5.0",
-    "pytest-cov>=3.0.0",
-    "flake8>=7.0.0",
-    "pyproject-flake8>=7.0.0",
-    "twine==6.1.0",
-    "Sphinx==8.2.3",
-    "watchdog==6.0.0",
+  "black==25.1.0",
+  "bumpver",
+  "isort==6.0.1",
+  "pip-tools",
+  "pre-commit>=4.0.0",
+  "pytest",
+  "pytest-django>=4.5.0",
+  "pytest-cov>=3.0.0",
+  "flake8>=7.0.0",
+  "pyproject-flake8>=7.0.0",
+  "twine==6.1.0",
+  "Sphinx==8.2.3",
+  "watchdog==6.0.0",
 ]
 
 [project.urls]
@@ -62,7 +60,7 @@ Tracker = "https://github.com/jsenecal/netbox-notices/issues"
 
 
 [tool.bumpver]
-current_version = "1.1.1"
+current_version = "1.1.2"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "chore: bump version {old_version} -> {new_version}"
 tag_pattern = "vMAJOR.MINOR.PATCH"
@@ -71,13 +69,8 @@ tag = true
 push = true
 
 [tool.bumpver.file_patterns]
-"pyproject.toml" = [
-    'current_version = "{version}"',
-    'version = "{version}"',
-]
-"notices/__init__.py" = [
-    '__version__ = "{version}"',
-]
+"pyproject.toml" = ['current_version = "{version}"', 'version = "{version}"']
+"notices/__init__.py" = ['__version__ = "{version}"']
 
 [tool.flake8]
 max-line-length = 120
@@ -85,19 +78,19 @@ max-complexity = 18
 extend-ignore = ["E203", "E266", "W503"]
 per-file-ignores = ["__init__.py:F401"]
 exclude = [
-    ".git",
-    "__pycache__",
-    "setup.py",
-    "build",
-    "dist",
-    "docs",
-    "releases",
-    ".venv",
-    ".tox",
-    ".mypy_cache",
-    ".pytest_cache",
-    ".vscode",
-    ".github",
+  ".git",
+  "__pycache__",
+  "setup.py",
+  "build",
+  "dist",
+  "docs",
+  "releases",
+  ".venv",
+  ".tox",
+  ".mypy_cache",
+  ".pytest_cache",
+  ".vscode",
+  ".github",
 ]
 # By default test codes will be linted.
 # tests
@@ -115,8 +108,15 @@ max-complexity = 18
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "F403"]
 "parsers/*" = ["E711", "E722"]
-"notices/tables.py" = ["E501"]  # Template strings in ActionsColumn can exceed line length
-".devcontainer/load_plugin_demo.py" = ["E402", "E501", "F841", "C901"]  # Django setup requires late imports, demo script complexity OK
+"notices/tables.py" = [
+  "E501",
+] # Template strings in ActionsColumn can exceed line length
+".devcontainer/load_plugin_demo.py" = [
+  "E402",
+  "E501",
+  "F841",
+  "C901",
+] # Django setup requires late imports, demo script complexity OK
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
NetBox commit [53345f1](https://github.com/netbox-community/netbox/commit/53345f194a90d9f4902daf94d8b44f3eea29d655) upgrades `strawberry-django` from 0.75.0 to 0.79.0 and replaces ALL occurrences of `FilterLookup[str]` with `StrFilterLookup`.

This throws a `DuplicatedTypeName` error in netbox-notices@1.11

PR changes the field type to match