### PR TITLE
fix(graphql): support NetBox 4.5.5+ StrFilterLookup + CI matrix

### DIFF
--- a/.devcontainer/Dockerfile-plugin_dev
+++ b/.devcontainer/Dockerfile-plugin_dev
@@ -1,4 +1,4 @@
-ARG NETBOX_VARIANT=v4.5.3-4.0.0
+ARG NETBOX_VARIANT=v4.5.5-4.0.2
 
 FROM ghcr.io/netbox-community/netbox:${NETBOX_VARIANT}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         netbox-version:
-          - v4.4.10
           - v4.5.2
           - v4.5.8
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,16 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        netbox-version:
+          - v4.4.10
+          - v4.5.2
+          - v4.5.8
+
+    name: NetBox ${{ matrix.netbox-version }}
+
     services:
       postgres:
         image: postgres:15-alpine
@@ -48,7 +58,7 @@ jobs:
       - name: Install NetBox
         run: |
           # Clone NetBox
-          git clone --depth 1 --branch v4.5.2 https://github.com/netbox-community/netbox.git /tmp/netbox
+          git clone --depth 1 --branch ${{ matrix.netbox-version }} https://github.com/netbox-community/netbox.git /tmp/netbox
 
           # Install NetBox dependencies
           pip install --upgrade pip

--- a/notices/graphql/filters.py
+++ b/notices/graphql/filters.py
@@ -3,6 +3,11 @@ from netbox.graphql.filters import PrimaryModelFilter
 from strawberry.scalars import ID
 from strawberry_django import FilterLookup
 
+try:
+    from strawberry_django import StrFilterLookup
+except ImportError:
+    StrFilterLookup = FilterLookup[str]
+
 from notices import models
 
 __all__ = (
@@ -17,43 +22,43 @@ __all__ = (
 
 @strawberry_django.filter_type(models.Maintenance, lookups=True)
 class MaintenanceFilter(PrimaryModelFilter):
-    name: FilterLookup[str] | None = strawberry_django.filter_field()
-    summary: FilterLookup[str] | None = strawberry_django.filter_field()
-    status: FilterLookup[str] | None = strawberry_django.filter_field()
+    name: StrFilterLookup | None = strawberry_django.filter_field()
+    summary: StrFilterLookup | None = strawberry_django.filter_field()
+    status: StrFilterLookup | None = strawberry_django.filter_field()
     provider_id: ID | None = strawberry_django.filter_field()
     acknowledged: bool | None = strawberry_django.filter_field()
 
 
 @strawberry_django.filter_type(models.Outage, lookups=True)
 class OutageFilter(PrimaryModelFilter):
-    name: FilterLookup[str] | None = strawberry_django.filter_field()
-    summary: FilterLookup[str] | None = strawberry_django.filter_field()
-    status: FilterLookup[str] | None = strawberry_django.filter_field()
+    name: StrFilterLookup | None = strawberry_django.filter_field()
+    summary: StrFilterLookup | None = strawberry_django.filter_field()
+    status: StrFilterLookup | None = strawberry_django.filter_field()
     provider_id: ID | None = strawberry_django.filter_field()
     acknowledged: bool | None = strawberry_django.filter_field()
 
 
 @strawberry_django.filter_type(models.Impact, lookups=True)
 class ImpactFilter(PrimaryModelFilter):
-    impact: FilterLookup[str] | None = strawberry_django.filter_field()
+    impact: StrFilterLookup | None = strawberry_django.filter_field()
     event_object_id: ID | None = strawberry_django.filter_field()
     target_object_id: ID | None = strawberry_django.filter_field()
 
 
 @strawberry_django.filter_type(models.EventNotification, lookups=True)
 class EventNotificationFilter(PrimaryModelFilter):
-    subject: FilterLookup[str] | None = strawberry_django.filter_field()
-    email_from: FilterLookup[str] | None = strawberry_django.filter_field()
+    subject: StrFilterLookup | None = strawberry_django.filter_field()
+    email_from: StrFilterLookup | None = strawberry_django.filter_field()
 
 
 @strawberry_django.filter_type(models.NotificationTemplate, lookups=True)
 class NotificationTemplateFilter(PrimaryModelFilter):
-    name: FilterLookup[str] | None = strawberry_django.filter_field()
-    slug: FilterLookup[str] | None = strawberry_django.filter_field()
-    event_type: FilterLookup[str] | None = strawberry_django.filter_field()
+    name: StrFilterLookup | None = strawberry_django.filter_field()
+    slug: StrFilterLookup | None = strawberry_django.filter_field()
+    event_type: StrFilterLookup | None = strawberry_django.filter_field()
 
 
 @strawberry_django.filter_type(models.PreparedNotification, lookups=True)
 class PreparedNotificationFilter(PrimaryModelFilter):
-    status: FilterLookup[str] | None = strawberry_django.filter_field()
-    subject: FilterLookup[str] | None = strawberry_django.filter_field()
+    status: StrFilterLookup | None = strawberry_django.filter_field()
+    subject: StrFilterLookup | None = strawberry_django.filter_field()


### PR DESCRIPTION
## Summary
- Fixes `DuplicatedTypeName` on NetBox 4.5.5+ by switching filter fields to `StrFilterLookup`, with a try/except fallback aliasing it to `FilterLookup[str]` for older `strawberry_django` (< 0.79)
- Keeps `FilterLookup` imported for future non-str parameterizations (e.g. `FilterLookup[bool]`)
- Bumps devcontainer NetBox to `v4.5.5-4.0.2`
- Replaces the single pinned NetBox CI version with a matrix (`v4.5.2`, `v4.5.8`) that exercises both sides of the strawberry_django 0.79 split

Picks up #16 (author unresponsive) and addresses the review feedback: no version bump, no unrelated `pyproject.toml` reformat, try/except compat shim instead of a hard swap.

Closes #16
Refs #17 #18

Credit to @elliot for identifying the fix and the original diff - preserved via `Co-authored-by` on the graphql and devcontainer commits.