### PR TITLE
docs: expand zensical site coverage

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,102 @@
+# Configuration
+
+All plugin behaviour is configured through the `PLUGINS_CONFIG["notices"]` dict in `configuration.py`. Every key has a default, so an empty dict is a valid configuration. NetBox must be restarted after any change.
+
+## Settings reference
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `allowed_content_types` | `["circuits.Circuit", "dcim.Device", "dcim.PowerFeed", "dcim.Site"]` | Content types that may be the target of an `Impact`. Format: `app_label.ModelName`. |
+| `ical_past_days_default` | `30` | How many days of past events to include in the iCal feed when the request does not specify `past_days`. |
+| `ical_cache_max_age` | `900` | `Cache-Control: max-age` (seconds) sent with the iCal subscription feed. |
+| `ical_token_placeholder` | `"changeme"` | Placeholder string shown in the calendar UI's iCal subscription URL. Cosmetic only; the user replaces it with their own API token. |
+| `event_history_days` | `30` | Window (days, looking back from now) for the event-history widgets shown on Provider, Circuit, Device, etc detail pages. |
+
+The settings are declared in `notices/__init__.py` as the `default_settings` dict on `NoticesConfig`. The defaults for `allowed_content_types` come from `notices/constants.py:DEFAULT_ALLOWED_CONTENT_TYPES`.
+
+## Example: full configuration
+
+```python
+PLUGINS_CONFIG = {
+    "notices": {
+        "allowed_content_types": [
+            "circuits.Circuit",
+            "dcim.Device",
+            "dcim.Interface",
+            "dcim.PowerFeed",
+            "dcim.PowerPanel",
+            "dcim.Rack",
+            "dcim.Site",
+            "ipam.IPAddress",
+            "ipam.Prefix",
+            "virtualization.VirtualMachine",
+            "virtualization.VMInterface",
+        ],
+        "ical_past_days_default": 14,
+        "ical_cache_max_age": 600,
+        "event_history_days": 60,
+    },
+}
+```
+
+## allowed_content_types
+
+This is the most important setting. It controls which NetBox object types can be linked to an event via the `Impact` model.
+
+### Behaviour
+
+- Forms (`ImpactForm`) only offer object types from this list.
+- The REST API rejects `POST /api/plugins/notices/impact/` requests where `target_content_type` is not in the list. Validation happens in `Impact.clean()`.
+- Object detail pages render the "Maintenance and Outage History" widget only when their type is in the list (the widget is registered dynamically per allowed type at app startup, see `notices/template_content.py`).
+- The list is case-insensitive at validation time, but the canonical form is `app_label.ModelName` with the model name in lowercase as Django stores content types.
+
+### Adding a new content type
+
+When you add a new content type to the list:
+
+1. **Restart NetBox.** Template extensions are registered at app-ready time and will not pick up the new type until restart.
+2. **Register a site/location resolver** for the new type (see [Site and Location Resolvers](developer/resolvers.md)). Without a resolver, the plugin emits a system check warning at startup, and impacts on objects of that type will not be findable via the site/region/location filters on the maintenance and outage list views.
+
+### Common content types
+
+| Content type | Notes |
+|--------------|-------|
+| `circuits.Circuit` | Built-in resolver maps to the circuit's terminations -> sites. |
+| `dcim.Device` | Built-in resolver returns the device's site (and location, if set). |
+| `dcim.PowerFeed` | Built-in resolver walks `PowerPanel.site` / `PowerPanel.location`. |
+| `dcim.Site` | Built-in resolver returns the site itself. |
+| `dcim.Interface` | Needs a custom resolver (resolves through `Interface.device`). |
+| `dcim.Rack` | Needs a custom resolver (resolves through `Rack.site` / `Rack.location`). |
+| `virtualization.VirtualMachine` | Needs a custom resolver (resolves through `VM.site` or `VM.cluster.site`). |
+| `ipam.Prefix` / `ipam.IPAddress` | Needs a custom resolver (typically scoped via `vrf` -> `tenant` rather than site). |
+
+## iCal feed settings
+
+Three settings shape the iCal feed behaviour:
+
+- `ical_past_days_default` is the default for the `?past_days=` query parameter. The view caps the user-provided value at 365 days.
+- `ical_cache_max_age` controls the `Cache-Control: public, max-age=<n>` header on subscription responses. ETag and `Last-Modified` are always sent and are derived from the maintenance queryset's `last_updated` aggregate. Set lower for fresher feeds, higher to reduce server load.
+- `ical_token_placeholder` is shown verbatim in the calendar template's "Subscribe" link. Replace it with a string that hints to your users they need to drop in their own token (for example `your-api-token-here`).
+
+The cache headers, ETag computation, and download-vs-subscribe handshake are documented in [Calendar and iCal Feed](events/calendar-and-ical.md).
+
+## event_history_days
+
+Controls the time window for the per-object event widgets injected onto NetBox detail pages by `notices.template_content`:
+
+- `ProviderEventsExtension` ("Maintenance and Outage Events" on Provider pages).
+- The dynamic per-content-type extensions ("Maintenance and Outage History" on Device, Circuit, Site, etc).
+
+Events are included if they meet any of:
+
+- `start >= now - event_history_days`, or
+- `end >= now` (still active or scheduled in the future), or
+- `end is null` (open-ended Outage with no resolution time).
+
+Lowering this value declutters busy detail pages; raising it gives historical context.
+
+## Settings precedence and changes
+
+Settings are read at app load time and merged with `default_settings`. Restart NetBox (`netbox` and `netbox-rq`) after any change.
+
+Per-tenant or per-deployment overrides (for example, different `allowed_content_types` for staging vs production) are typically managed by templating `configuration.py` from your config-management system; the plugin itself does not provide a runtime override mechanism.

--- a/docs/events/calendar-and-ical.md
+++ b/docs/events/calendar-and-ical.md
@@ -1,0 +1,121 @@
+# Calendar and iCal Feed
+
+The plugin ships two complementary calendar features:
+
+- An **interactive calendar view** in the NetBox UI (Plugins -> Notices -> Calendar) backed by FullCalendar and the REST API.
+- An **iCal feed** at `/api/plugins/notices/ical/` for subscription from any external calendar app (Google Calendar, Outlook, Apple Calendar, Thunderbird, etc).
+
+## Interactive calendar
+
+Reach it from the menu under **Notices -> Events -> Calendar**, or directly at `/plugins/notices/maintenance/calendar/`.
+
+The view uses FullCalendar with month, week, and day modes. Events are colour-coded by type and status (Maintenance: status colour from `MaintenanceTypeChoices`; Outage: status colour from `OutageStatusChoices`). Clicking an event opens a quick summary modal with status, provider, timing, and a deep link to the full detail view. The page also shows a "Subscribe" link with a URL template using `ical_token_placeholder` from the plugin settings, so users know where to paste their token.
+
+The calendar requires `notices.view_maintenance` and renders Maintenance events; Outages are not currently represented in the FullCalendar view (they appear in the dashboard timeline and the iCal feed if you add them later -- track upstream).
+
+## iCal feed
+
+The feed endpoint is:
+
+```
+https://your-netbox/api/plugins/notices/ical/
+```
+
+It returns a `text/calendar; charset=utf-8` response containing every Maintenance event matching the query parameters.
+
+### Authentication
+
+The view tries three authentication methods in order:
+
+1. **URL token** -- `?token=<plaintext>`. Supports both v1 plaintext tokens and v2 `nbt_<key>.<plaintext>` tokens. This is the only mode that works with most calendar apps, since they cannot send custom headers on a subscription URL.
+2. **`Authorization` header** -- `Authorization: Token <plaintext>`. Useful for cron jobs and `curl` scripts.
+3. **Session cookie** -- works when you open the URL in a logged-in browser.
+
+If `LOGIN_REQUIRED = False` is set in NetBox configuration, anonymous requests are also accepted (the queryset is then unrestricted).
+
+The token's user must have `notices.view_maintenance`. Disabled tokens, expired tokens, and inactive users are rejected with `403 Forbidden`.
+
+### Query parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `token` | -- | API token (see above). |
+| `past_days` | `ical_past_days_default` (default 30) | Include events with `start >= now - past_days days`. Capped at 365. |
+| `provider` | -- | Filter by provider slug. Mutually exclusive with `provider_id`. |
+| `provider_id` | -- | Filter by provider PK. |
+| `status` | -- | Comma-separated status list (case-insensitive). Invalid statuses are silently dropped; if all are invalid, no status filter is applied. |
+| `download` | `false` | If truthy (`true`/`1`/`yes`), set `Content-Disposition: attachment; filename="netbox-maintenance-YYYY-MM-DD.ics"` so browsers download instead of subscribe. |
+
+Unknown parameters are ignored.
+
+### Examples
+
+Subscribe to all events in the last 30 days and beyond:
+
+```
+https://netbox.example.com/api/plugins/notices/ical/?token=YOUR_TOKEN
+```
+
+Only confirmed events from a specific provider, last 7 days:
+
+```
+https://netbox.example.com/api/plugins/notices/ical/?token=YOUR_TOKEN&provider=zayo&status=CONFIRMED&past_days=7
+```
+
+Multiple statuses:
+
+```
+.../ical/?token=YOUR_TOKEN&status=CONFIRMED,IN-PROCESS
+```
+
+Download as a one-off file:
+
+```
+.../ical/?token=YOUR_TOKEN&download=true
+```
+
+### Subscription URL guidelines
+
+| Calendar | Where to paste the URL |
+|----------|------------------------|
+| Google Calendar | Settings -> Add calendar -> From URL |
+| Outlook (web) | Calendar -> Add calendar -> Subscribe from web |
+| Apple Calendar (macOS / iOS) | File -> New Calendar Subscription |
+| Thunderbird | Calendar -> New Calendar -> On the network |
+
+Most clients refresh on their own schedule (Google: every few hours; Apple: configurable). The plugin caches its response for 15 minutes by default (`ical_cache_max_age`), so back-to-back fetches don't query the database repeatedly.
+
+### Caching and conditional requests
+
+The view computes a deterministic ETag from `(query parameters, latest last_updated, count)` of the matching queryset. The response always includes:
+
+- `ETag: <md5 hex>` -- conditional request validator.
+- `Last-Modified: <RFC 1123 date>` -- the most recent `last_updated` of any matching maintenance.
+- `Cache-Control: public, max-age=<ical_cache_max_age>` -- only on subscription mode (not when `download=true`).
+
+If the client sends `If-None-Match: <etag>`, the view returns `304 Not Modified` with no body. Same for `If-Modified-Since`.
+
+### Format details
+
+The feed conforms to RFC 5545 with these conventions:
+
+- Calendar metadata: `PRODID: -//NetBox Vendor Notification Plugin//EN`, `VERSION: 2.0`, `CALSCALE: GREGORIAN`, `X-WR-CALNAME: NetBox Maintenance Events`, `X-WR-TIMEZONE: UTC`.
+- Each event: `UID: maintenance-<id>@<host>`, `DTSTAMP: now`, `DTSTART/DTEND` from the maintenance window, `SUMMARY` is `<name> - <summary>`, `LOCATION` is the provider name, `CATEGORIES` is the maintenance status.
+- `STATUS` is mapped from the maintenance status:
+
+| Maintenance status | iCal STATUS |
+|--------------------|-------------|
+| `TENTATIVE` | TENTATIVE |
+| `CONFIRMED`, `IN-PROCESS`, `COMPLETED` | CONFIRMED |
+| `CANCELLED`, `RE-SCHEDULED` | CANCELLED |
+| `UNKNOWN` (or anything else) | TENTATIVE |
+
+- `DESCRIPTION` includes `Provider: ...`, `Status: ...`, optional `Internal Ticket: ...`, the affected-objects list (`<target> (<impact>)`) when the maintenance has impacts, and the `comments` field if non-empty.
+- `URL` points at the maintenance detail page using the request's scheme and `Host` header.
+
+The mapping logic lives in `notices/ical_utils.py`. Outages are not currently emitted in the iCal feed; the feed is Maintenance-only by design (calendar apps want bounded windows, and Outages may be open-ended).
+
+## See also
+
+- [Outgoing Notifications](../outgoing-notifications.md) -- a separate, different feature that *generates* iCal attachments for outbound notifications using a customizable BCOP-compliant template per `NotificationTemplate`.
+- [REST API](../api/rest-api.md) for the underlying maintenance / outage / impact endpoints.

--- a/docs/events/impact.md
+++ b/docs/events/impact.md
@@ -1,0 +1,154 @@
+# Impact Tracking
+
+The `Impact` model is what turns a Maintenance or Outage event from a free-form notice into structured data. Each `Impact` row is a (event, target object, impact level) tuple. Both ends use Django's `GenericForeignKey`, so a single Impact model handles every supported pair: Maintenance-on-Circuit, Maintenance-on-Device, Outage-on-Site, etc.
+
+## Model
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `event_content_type` | FK -> `ContentType` | Limited to `notices.maintenance` and `notices.outage`. |
+| `event_object_id` | PositiveInteger (indexed) | PK of the linked event. |
+| `event` | GenericForeignKey | Resolved Maintenance or Outage instance. |
+| `target_content_type` | FK -> `ContentType` | Must be in `allowed_content_types`. |
+| `target_object_id` | PositiveInteger (indexed) | PK of the affected NetBox object. |
+| `target` | GenericForeignKey | Resolved target instance (Circuit, Device, Site, ...). |
+| `impact` | CharField (choices, nullable) | Severity level. See [Impact Levels](#impact-levels). |
+| `sites` | M2M -> `dcim.Site` | Cached site membership of the target. Populated by `refresh_sites()`. |
+| `locations` | M2M -> `dcim.Location` | Cached location membership of the target. |
+| `tags` | M2M -> NetBox Tag | Standard tagging. |
+
+A `unique_together` constraint on `(event_content_type, event_object_id, target_content_type, target_object_id)` prevents linking the same event to the same target more than once.
+
+## Impact levels
+
+Defined in `notices/choices.py:ImpactTypeChoices` (BCOP standard).
+
+| Level | Colour | Meaning |
+|-------|--------|---------|
+| `NO-IMPACT` | green | Maintenance affects this object's path but no observable degradation. |
+| `REDUCED-REDUNDANCY` | yellow | Object remains in service but with one or more redundant paths offline. |
+| `DEGRADED` | orange | Object is in service but not at full capacity / quality. |
+| `OUTAGE` | red | Object will be entirely down. |
+
+Impact level may be `null` (no level recorded yet); the `Impact` table sorts by level so unknowns appear first by default.
+
+## Allowed target types
+
+Validation in `Impact.clean()` rejects any `target_content_type` that is not present in `PLUGINS_CONFIG["notices"]["allowed_content_types"]`. The check is case-insensitive but stores the canonical lowercase form. Forms only offer types from this list.
+
+If you change `allowed_content_types`, restart NetBox so the dynamically-registered template extensions and form choices update.
+
+## Site and location cache
+
+Filtering "show me every maintenance affecting any device in site X" naively requires walking every Impact's `target` GenericForeignKey, then dispatching to model-specific code to resolve a Site. That doesn't scale and you can't index it.
+
+The plugin solves this with two cached M2M fields on `Impact`:
+
+- `Impact.sites` -- the set of Sites the target belongs to.
+- `Impact.locations` -- the set of Locations the target belongs to.
+
+Both are populated by `Impact.refresh_sites()`, which calls into the **resolver registry** in `notices/resolvers.py` -- a per-content-type lookup of small functions that know how to extract Site/Location PKs from an instance of that type.
+
+`refresh_sites()` is called automatically by `notices.signals` whenever:
+
+- An Impact is saved.
+- A target object is saved (so a Device moving to a new Site updates every Impact pointing at it).
+- A target object is deleted (cascade clears the M2M).
+
+The list filters on Maintenance and Outage (`site_id`, `region_id`, `site_group_id`, `location_id`) traverse these cached M2Ms, which makes them fast, indexable, and capable of region/site-group rollups for free.
+
+### Adding new content types
+
+If you add a content type to `allowed_content_types` that does not have a resolver registered, `notices.checks` emits a startup warning, and impacts on objects of that type will have empty `sites`/`locations` -- they will be invisible to the site-scoped filters.
+
+See [Site and Location Resolvers](../developer/resolvers.md) for how to register a resolver for a custom type.
+
+## Validation rules
+
+`Impact.clean()` enforces:
+
+1. `target_content_type` must be in `allowed_content_types`.
+2. `event_content_type` must be `notices.maintenance` or `notices.outage`.
+3. The parent event must not be in a frozen state. You cannot add or modify Impacts on Maintenance with status `COMPLETED`/`CANCELLED` or Outage with status `RESOLVED`.
+
+Rule 3 is the audit-integrity guarantee: once an event is closed, its impact ledger is immutable.
+
+## Audit trail
+
+`Impact.to_objectchange()` overrides NetBox's default to set `related_object` to the parent event. This causes Impact changes to appear in the **event's** changelog, so the maintenance or outage detail page shows a unified timeline of "added impact for Circuit XYZ at 14:32, removed impact for Device ABC at 14:35".
+
+The same trick is used for `EventNotification.to_objectchange()`.
+
+## REST API
+
+```
+GET    /api/plugins/notices/impact/
+POST   /api/plugins/notices/impact/
+GET    /api/plugins/notices/impact/{id}/
+PATCH  /api/plugins/notices/impact/{id}/
+PUT    /api/plugins/notices/impact/{id}/
+DELETE /api/plugins/notices/impact/{id}/
+```
+
+### Creating an Impact
+
+The serializer requires the content-type integers, not the model name strings, on input. Resolve them once at parser startup:
+
+```python
+import requests
+
+response = requests.get(
+    "https://netbox.example.com/api/extras/content-types/?app_label=notices&model=maintenance",
+    headers={"Authorization": f"Token {token}"},
+)
+maintenance_ct = response.json()["results"][0]["id"]
+```
+
+Then create the Impact:
+
+```http
+POST /api/plugins/notices/impact/
+Authorization: Token YOUR_API_TOKEN
+Content-Type: application/json
+
+{
+  "event_content_type": 245,
+  "event_object_id": 17,
+  "target_content_type": 12,
+  "target_object_id": 412,
+  "impact": "OUTAGE"
+}
+```
+
+The response includes nested representations for both `event` and `target`:
+
+```json
+{
+  "id": 88,
+  "url": "https://.../api/plugins/notices/impact/88/",
+  "event": { "id": 17, "name": "MAINT-2026-001", "status": "CONFIRMED", ... },
+  "target": { "id": 412, "cid": "ZAYO/CKT/12345", ... },
+  "impact": "OUTAGE",
+  "tags": [],
+  "created": "2026-04-27T13:01:55Z",
+  "last_updated": "2026-04-27T13:01:55Z"
+}
+```
+
+When the target is a Circuit, the full `CircuitSerializer` is used; for other types, a minimal `{id, name, type}` shape is returned (per `ImpactSerializer.get_target`).
+
+## Filtering Impacts
+
+The `ImpactFilterSet` filters on `id`, `event_content_type`, `event_object_id`, `target_content_type`, `target_object_id`, and `impact` level. To find every impact attached to maintenance #17, filter on `event_object_id=17` and `event_content_type=<maintenance ct>`.
+
+The richer site-scoped filters live on the parent event filtersets (`MaintenanceFilterSet`, `OutageFilterSet`) and traverse the `Impact.sites` / `Impact.locations` cache; see [Maintenance](maintenance.md) and [Outage](outage.md).
+
+## UI behaviour
+
+There is no top-level "Impacts" list view; impacts are managed in the context of their parent event:
+
+- **Maintenance / Outage detail page** shows the impact table with Sites and Locations columns derived from the cached M2M.
+- **+ Add Impact** opens `ImpactEditView` with the parent event pre-filled.
+- **Object detail pages** (Device, Circuit, Site, ...) show the inverse: a "Maintenance and Outage History" widget listing every event that has ever impacted this object within the `event_history_days` window.
+
+The per-object widget is registered dynamically: at app-ready time, `notices.template_content` reads `allowed_content_types` and creates one `PluginTemplateExtension` subclass per type.

--- a/docs/events/maintenance.md
+++ b/docs/events/maintenance.md
@@ -1,0 +1,120 @@
+# Maintenance Events
+
+A `Maintenance` represents a planned, scheduled maintenance window for a provider's service. Maintenance events have a required start and end time, a status that follows a defined lifecycle, and zero or more `Impact` records linking them to affected NetBox objects.
+
+## Model
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | CharField (100) | Provider-supplied event ID or ticket. Required. |
+| `summary` | CharField (200) | One-line description. Required. |
+| `provider` | FK -> `circuits.Provider` | Required. `related_name="maintenance"`. |
+| `start` | DateTimeField (indexed) | Required. |
+| `end` | DateTimeField (indexed) | Required. Must be after `start`. |
+| `status` | CharField (choices) | See [Status Workflow](#status-workflow) below. |
+| `original_timezone` | CharField (63) | IANA tz name from the provider's notification, used for "show in original tz" display. |
+| `internal_ticket` | CharField (100) | Your organisation's change reference. |
+| `acknowledged` | BooleanField | Whether the event has been acknowledged by the NOC. |
+| `comments` | TextField | Free-form notes. |
+| `impact` | TextField | Free-form impact description (separate from the structured `Impact` records). |
+| `replaces` | FK -> `Maintenance` | Self-reference for rescheduled events. Set when a new event replaces an old one; the old event's status is auto-set to `RE-SCHEDULED` via signal. |
+| `tags` | M2M -> NetBox Tag | Standard NetBox tagging. |
+
+The model inherits from `BaseEvent` (an abstract `NetBoxModel`) which contributes `name`, `summary`, `provider`, `start`, `original_timezone`, `internal_ticket`, `acknowledged`, `comments`, and `impact`. Maintenance adds `end` (required), `status`, and `replaces`.
+
+`clone_fields` includes everything except `status` and `replaces`, so the **Clone** action in the UI gives you a fresh editable copy.
+
+## Status workflow
+
+Status values are defined in `notices/choices.py:MaintenanceTypeChoices` and follow the BCOP standard.
+
+```
+                 +-> CANCELLED
+                 |
+TENTATIVE -> CONFIRMED -> IN-PROCESS -> COMPLETED
+     |                |
+     |                +-> RE-SCHEDULED (set automatically when a replacement is created)
+     |
+     +-> UNKNOWN (used when the provider has not yet specified)
+```
+
+| Status | Colour | When to use |
+|--------|--------|-------------|
+| `TENTATIVE` | yellow | Initial state when a notification is parsed; provider has proposed a window. |
+| `CONFIRMED` | green | Provider has confirmed the window. Acknowledge once you've reviewed it. |
+| `IN-PROCESS` | orange | Maintenance has started. Set automatically only by the **Mark In Progress** quick action. |
+| `COMPLETED` | indigo | Maintenance finished successfully. |
+| `CANCELLED` | gray | Provider cancelled before the start time. |
+| `RE-SCHEDULED` | teal | Auto-set on the original event when a new Maintenance is created with `replaces=<this event>`. |
+| `UNKNOWN` | blue | Used when status cannot be determined. |
+
+### Quick actions
+
+The Operations dropdown on the Maintenance detail page exposes four POST-only actions and one GET form. All require `notices.change_maintenance`.
+
+| Action | URL | Effect |
+|--------|-----|--------|
+| Acknowledge | `POST .../maintenance/<id>/acknowledge/` | Sets `acknowledged = True`. Idempotent. |
+| Mark In Progress | `POST .../maintenance/<id>/mark-in-progress/` | Sets `status = IN-PROCESS`. Refused if already `COMPLETED` or `CANCELLED`. |
+| Mark Completed | `POST .../maintenance/<id>/mark-completed/` | Sets `status = COMPLETED`. Refused if `CANCELLED`. No-op if already `COMPLETED`. |
+| Cancel | `GET/POST .../maintenance/<id>/cancel/` | Shows confirmation page on GET; sets `status = CANCELLED` on POST. Refused if already `COMPLETED` or `CANCELLED`. |
+| Reschedule | `GET/POST .../maintenance/<id>/reschedule/` | Opens an edit form for a *new* Maintenance pre-populated from the original; setting `replaces` automatically transitions the original to `RE-SCHEDULED` via post-save signal. |
+
+Each quick action snapshots the object first so the changelog records the change.
+
+### Reschedule flow
+
+1. User clicks **Reschedule** on the original Maintenance.
+2. `MaintenanceRescheduleView` builds a fresh, unsaved `Maintenance` instance, copies every field from the original except `id`/`created`/`last_updated`, sets `replaces` to the original, resets `status` to `TENTATIVE`.
+3. User edits the new start/end and saves.
+4. The post-save signal observes that the new event has `replaces` set and updates the original event's status to `RE-SCHEDULED`.
+
+Both events remain in the database; you can navigate from the new event to the replaced one via the `replaces` link, and the list view exposes a `has_replaces` filter to find rescheduled events.
+
+## Timezone handling
+
+Provider notifications often quote times in the provider's local timezone. The plugin stores `start` and `end` in UTC (Django's standard) and additionally records `original_timezone` so the UI can display both:
+
+- `Maintenance.get_start_in_original_tz()` returns the start time in `original_timezone` if set, otherwise falls back to `start` as-is.
+- `Maintenance.get_end_in_original_tz()` is the same for `end`.
+- `Maintenance.has_timezone_difference()` returns `True` only when `original_timezone` is set *and* differs from the NetBox active timezone, so the template only renders the dual display when it would actually be useful.
+
+`original_timezone` accepts any IANA name; the form exposes the curated list in `notices/choices.py:TimeZoneChoices` (Africa, America, Asia, Australia, Europe, Pacific groups), but anything `zoneinfo.ZoneInfo()` accepts will work.
+
+## Validation
+
+`Maintenance.clean()` (inherited from `BaseEvent`) enforces `end >= start`.
+
+`Impact.clean()` enforces that you cannot add or modify Impacts on a Maintenance whose status is `COMPLETED` or `CANCELLED`. Once a maintenance is finalized, its impact set is frozen for audit purposes.
+
+## Detail view
+
+The Maintenance detail page (`MaintenanceView`) renders four panels:
+
+- **Operations** dropdown (the quick actions above plus standard Edit/Clone/Delete).
+- **Details** card with all model fields, including the original-timezone display when applicable.
+- **Impacts** table with prefetched `sites` and `locations` columns (resolved via the [resolver registry](../developer/resolvers.md)).
+- **Notifications** table listing every `EventNotification` linked to this event.
+- **Timeline** showing the most recent 20 changelog entries with status-coloured icons.
+
+## REST API
+
+The Maintenance endpoints are documented in detail in the [REST API](../api/rest-api.md) reference. Quick reference:
+
+```
+GET    /api/plugins/notices/maintenance/
+POST   /api/plugins/notices/maintenance/
+GET    /api/plugins/notices/maintenance/{id}/
+PATCH  /api/plugins/notices/maintenance/{id}/
+PUT    /api/plugins/notices/maintenance/{id}/
+DELETE /api/plugins/notices/maintenance/{id}/
+```
+
+Filterable fields (via `MaintenanceFilterSet`):
+
+- `id`, `name`, `summary`, `status`, `provider_id`, `start`, `end`, `original_timezone`, `internal_ticket`, `acknowledged`, `impact`, `comments`
+- `replaces_id` (find the new event that replaces a given one)
+- `has_replaces=true|false`
+- `site_id`, `region_id`, `site_group_id`, `location_id` (traverse `Impact.sites` / `Impact.locations` cache)
+
+Free-text search via `?q=` matches `name`, `summary`, `internal_ticket`, and `impact`.

--- a/docs/events/outage.md
+++ b/docs/events/outage.md
@@ -1,0 +1,154 @@
+# Outage Events
+
+An `Outage` represents an unplanned service incident. Outages share the same `Impact` and `EventNotification` machinery as Maintenance events but have a different status workflow that mirrors a typical incident lifecycle, and they support an open-ended (`end is null`) state until the incident is resolved.
+
+## Model
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | CharField (100) | Provider event ID or your own outage tracker ID. Required. |
+| `summary` | CharField (200) | One-line description. Required. |
+| `provider` | FK -> `circuits.Provider` | Required. |
+| `start` | DateTimeField (indexed) | Defaults to `timezone.now()` so newly-reported outages can be created without supplying a start. |
+| `reported_at` | DateTimeField | Defaults to `timezone.now()`. When the outage was first reported (may differ from `start`). |
+| `end` | DateTimeField (indexed, nullable) | Optional until status becomes `RESOLVED`, at which point it becomes required. |
+| `estimated_time_to_repair` | DateTimeField (nullable) | The current ETR. Tracked through changelog so you can audit how the estimate evolved. |
+| `status` | CharField (choices) | See [Status Workflow](#status-workflow). |
+| `original_timezone` | CharField (63) | IANA tz name from the provider notification. |
+| `internal_ticket` | CharField (100) | Your tracking ticket reference. |
+| `acknowledged` | BooleanField | NOC acknowledgement. |
+| `comments` | TextField | Free-form notes. |
+| `impact` | TextField | Free-form impact description. |
+| `tags` | M2M -> NetBox Tag | Standard tagging. |
+
+Like `Maintenance`, `Outage` extends `BaseEvent` and adds outage-specific fields (`reported_at`, `estimated_time_to_repair`, status choices).
+
+## Status workflow
+
+Status values are defined in `notices/choices.py:OutageStatusChoices`. Unlike Maintenance, the workflow is a soft progression that reflects the operational state of incident response.
+
+```
+REPORTED -> INVESTIGATING -> IDENTIFIED -> MONITORING -> RESOLVED
+```
+
+You may move backward (for example, `MONITORING -> INVESTIGATING` if the fix did not stick); the plugin does not enforce a strict FSM. The only validation is that `end` is required when transitioning to `RESOLVED` -- enforced by `Outage.clean()`.
+
+| Status | Colour | Meaning |
+|--------|--------|---------|
+| `REPORTED` | red | Outage detected and logged; no investigation yet. |
+| `INVESTIGATING` | orange | Triage in progress; root cause not yet known. |
+| `IDENTIFIED` | yellow | Root cause known; fix being prepared or applied. |
+| `MONITORING` | blue | Fix applied; watching for stability. |
+| `RESOLVED` | green | Service fully restored. `end` must be set. |
+
+## ETR tracking
+
+`estimated_time_to_repair` is a single field, but every change is captured in the standard NetBox changelog. The detail view's timeline panel shows ETR revisions chronologically with diffs, so you can see how the estimate evolved across the incident.
+
+When the provider issues a new ETR:
+
+1. `PATCH /api/plugins/notices/outage/<id>/` with `{"estimated_time_to_repair": "2026-04-27T15:00:00Z"}`
+2. The post-save changelog entry records the old and new value.
+3. The detail timeline highlights the change with a status-coloured icon.
+
+To clear the ETR, send `null`:
+
+```http
+PATCH /api/plugins/notices/outage/42/
+Content-Type: application/json
+
+{"estimated_time_to_repair": null}
+```
+
+## Validation
+
+`Outage.clean()` enforces:
+
+- `end >= start` (inherited from `BaseEvent`).
+- `end` is required when `status == "RESOLVED"`.
+
+Impacts on `RESOLVED` outages are frozen by `Impact.clean()` (alongside `COMPLETED` and `CANCELLED` events).
+
+## Open-ended outages
+
+Because `end` is nullable, you can create an outage immediately when it's reported:
+
+```json
+POST /api/plugins/notices/outage/
+{
+  "name": "OUT-2026-042",
+  "summary": "Fiber cut on Main Street",
+  "provider": 7,
+  "status": "REPORTED"
+}
+```
+
+`start` defaults to "now". The outage will appear on the dashboard, calendar, and event-history widgets as ongoing. Set `end` and transition to `RESOLVED` once service is restored.
+
+The dashboard counts an outage as active if its status is one of `REPORTED`, `INVESTIGATING`, `IDENTIFIED`, or `MONITORING`. Open-ended outages also appear in the per-object event-history widget regardless of `event_history_days`, because they are presumed ongoing.
+
+## Detail view
+
+The Outage detail page renders the same panel layout as Maintenance:
+
+- Standard Edit / Clone / Delete actions (no Maintenance-specific quick actions).
+- Details card with ETR and reported-at fields.
+- Impacts table with sites/locations columns.
+- Notifications table.
+- Timeline showing all status changes and ETR revisions.
+
+## REST API
+
+```
+GET    /api/plugins/notices/outage/
+POST   /api/plugins/notices/outage/
+GET    /api/plugins/notices/outage/{id}/
+PATCH  /api/plugins/notices/outage/{id}/
+PUT    /api/plugins/notices/outage/{id}/
+DELETE /api/plugins/notices/outage/{id}/
+```
+
+Filterable fields (via `OutageFilterSet`): `id`, `name`, `summary`, `status`, `provider_id`, `start`, `end`, `reported_at`, `estimated_time_to_repair`, `original_timezone`, `internal_ticket`, `acknowledged`, plus the same `site_id` / `region_id` / `site_group_id` / `location_id` site-scoping filters as Maintenance.
+
+## Example: creating an outage
+
+```http
+POST /api/plugins/notices/outage/
+Authorization: Token YOUR_API_TOKEN
+Content-Type: application/json
+
+{
+  "name": "OUT-2026-001",
+  "summary": "Fiber cut on Main Street",
+  "provider": 7,
+  "status": "INVESTIGATING",
+  "estimated_time_to_repair": "2026-04-27T18:00:00Z",
+  "internal_ticket": "INC-12345"
+}
+```
+
+Then attach an impact (see [Impact Tracking](impact.md) for content-type IDs):
+
+```http
+POST /api/plugins/notices/impact/
+Authorization: Token YOUR_API_TOKEN
+Content-Type: application/json
+
+{
+  "event_content_type": 245,
+  "event_object_id": 42,
+  "target_content_type": 17,
+  "target_object_id": 123,
+  "impact": "OUTAGE"
+}
+```
+
+Resolve the outage:
+
+```http
+PATCH /api/plugins/notices/outage/42/
+{
+  "status": "RESOLVED",
+  "end": "2026-04-27T17:42:00Z"
+}
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,105 @@
+# Installation
+
+This page covers installing and enabling the `netbox-notices` plugin in an existing NetBox deployment.
+
+## Requirements
+
+| Component | Required version |
+|-----------|------------------|
+| NetBox | 4.5.0 or later |
+| Python | 3.10, 3.11, 3.12, 3.13, or 3.14 |
+| PostgreSQL | Whatever your NetBox version requires |
+
+The plugin module name on disk is `notices` (note: not `netbox_notices`). The PyPI distribution name is `netbox-notices`.
+
+## Install from PyPI
+
+Activate the NetBox virtual environment and install via pip:
+
+```bash
+source /opt/netbox/venv/bin/activate
+pip install netbox-notices
+```
+
+To make the install persist across NetBox upgrades, add the package to your `local_requirements.txt`:
+
+```bash
+echo netbox-notices >> /opt/netbox/local_requirements.txt
+```
+
+## Enable the plugin
+
+Edit `configuration.py` (typically `/opt/netbox/netbox/netbox/configuration.py`) and add `notices` to the `PLUGINS` list:
+
+```python
+PLUGINS = [
+    "notices",
+]
+
+PLUGINS_CONFIG = {
+    "notices": {},
+}
+```
+
+The empty dict accepts the defaults documented on the [Configuration](configuration.md) page. You almost certainly want to extend `allowed_content_types` to include the model classes you intend to link impacts to (Devices, VirtualMachines, etc).
+
+## Apply database migrations
+
+```bash
+cd /opt/netbox
+source venv/bin/activate
+python netbox/manage.py migrate
+```
+
+The plugin's migrations live under `notices/migrations/` and will create the following tables:
+
+- `notices_maintenance`
+- `notices_outage`
+- `notices_impact` (with M2M tables `notices_impact_sites` and `notices_impact_locations`)
+- `notices_eventnotification`
+- `notices_notificationtemplate`
+- `notices_templatescope`
+- `notices_preparednotification` (with `notices_preparednotification_contacts`)
+
+## Restart NetBox
+
+```bash
+sudo systemctl restart netbox netbox-rq
+```
+
+After restart you should see a new top-level **Notices** menu in the NetBox UI with the **Dashboard**, **Notifications**, **Events**, and **Messaging** groups.
+
+## Verify the install
+
+Hit the API root and confirm the `notices` plugin is listed:
+
+```bash
+curl -H "Authorization: Token YOUR_API_TOKEN" \
+  https://netbox.example.com/api/plugins/notices/
+```
+
+You should see the available endpoints (`maintenance/`, `outage/`, `impact/`, `eventnotification/`, `notification-templates/`, `prepared-notifications/`, `sent-notifications/`).
+
+## Upgrading
+
+To upgrade to a newer release:
+
+```bash
+source /opt/netbox/venv/bin/activate
+pip install --upgrade netbox-notices
+python /opt/netbox/netbox/manage.py migrate
+sudo systemctl restart netbox netbox-rq
+```
+
+Always read the [Changelog](changelog.md) before upgrading to confirm there are no breaking changes for your configuration.
+
+## Migrating from netbox-circuitmaintenance
+
+There is **no automatic upgrade path** from `jasonyates/netbox-circuitmaintenance`. The data model has changed:
+
+- The `CircuitMaintenance` model is replaced by `Maintenance`.
+- `CircuitMaintenanceImpact` (which referenced a Circuit by FK) is replaced by `Impact`, which uses a GenericForeignKey to support any allowed content type.
+- A new `Outage` model exists for unplanned events.
+- The notification storage model has been renamed to `EventNotification` and also uses a GenericForeignKey.
+
+If you are migrating, export your old maintenance and impact data via the original plugin's REST API and re-import via this plugin's API. See the [REST API](api/rest-api.md) reference for endpoint details.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,68 @@
+# Permissions
+
+The plugin defines standard Django permissions for each model: `add`, `change`, `delete`, and `view`. Permissions are namespaced under `notices.<perm>_<model>`.
+
+## Permission reference
+
+| Permission | Required to |
+|------------|-------------|
+| `notices.view_maintenance` | View Maintenance list, detail, dashboard, calendar, iCal feed |
+| `notices.add_maintenance` | Create Maintenance events |
+| `notices.change_maintenance` | Edit Maintenance events; use the Acknowledge / Mark in Progress / Mark Completed / Cancel / Reschedule quick actions |
+| `notices.delete_maintenance` | Delete Maintenance events |
+| `notices.view_outage` | View Outage list and detail |
+| `notices.add_outage` | Create Outage events |
+| `notices.change_outage` | Edit Outage events |
+| `notices.delete_outage` | Delete Outage events |
+| `notices.view_impact` | View Impact records (no dedicated list view; viewed through events) |
+| `notices.add_impact` | Add an Impact, linking an event to a target object |
+| `notices.change_impact` | Edit an Impact |
+| `notices.delete_impact` | Remove an Impact |
+| `notices.view_eventnotification` | View received provider notifications |
+| `notices.add_eventnotification` | Upload a new EventNotification (typically done via the API by a parser) |
+| `notices.delete_eventnotification` | Delete an EventNotification |
+| `notices.view_notificationtemplate` | View NotificationTemplates |
+| `notices.add_notificationtemplate` | Create new NotificationTemplates |
+| `notices.change_notificationtemplate` | Edit NotificationTemplates and their TemplateScopes |
+| `notices.delete_notificationtemplate` | Delete NotificationTemplates |
+| `notices.view_preparednotification` | View PreparedNotifications and the Sent Notifications proxy list |
+| `notices.add_preparednotification` | Create PreparedNotifications |
+| `notices.change_preparednotification` | Edit PreparedNotifications and transition status (e.g. mark as ready, sent, delivered, failed) |
+| `notices.delete_preparednotification` | Delete PreparedNotifications |
+
+The `SentNotification` proxy model uses the same `view_preparednotification` permission rather than introducing its own.
+
+## Recommended role bindings
+
+| Role | Suggested permissions |
+|------|------------------------|
+| **NOC operator** (handles live events) | `view_*`, `change_maintenance`, `change_outage`, `add_impact`, `change_impact` |
+| **NOC supervisor** (full event lifecycle) | All of the above plus `add_maintenance`, `add_outage`, `delete_*` for events |
+| **Notification approver** | `view_preparednotification`, `change_preparednotification` (so they can transition `draft` -> `ready`) |
+| **External delivery service** (API token) | `view_preparednotification`, `change_preparednotification` (to mark `ready` -> `sent` -> `delivered/failed`); `add_eventnotification` if it also stores received emails |
+| **Provider parser** (API token) | `add_maintenance`, `add_outage`, `add_impact`, `add_eventnotification`, `change_maintenance`, `change_outage` |
+| **Read-only auditor** | All `view_*` permissions |
+
+## Object-level permissions
+
+The plugin uses NetBox's standard `RestrictedQuerySet` patterns, so NetBox's object-level permission constraints (filter by JSON expression) work for every model. For example, restrict a parser token to a specific Provider:
+
+```json
+{ "provider": 7 }
+```
+
+attached to a `notices.add_maintenance` permission with `users` set to the parser user limits that token to creating Maintenance events for provider 7 only.
+
+## API tokens for the iCal feed
+
+The iCal feed (`/api/plugins/notices/ical/`) accepts three authentication modes (in order):
+
+1. `?token=<plaintext>` URL parameter (works with both v1 and v2 NetBox tokens; v2 tokens have the `nbt_<key>.<plaintext>` form).
+2. `Authorization: Token <plaintext>` HTTP header.
+3. Browser session cookie (when subscribing from a logged-in browser).
+
+If `LOGIN_REQUIRED = False` is set in NetBox configuration, anonymous access is also accepted.
+
+The feed checks `notices.view_maintenance` on the resolved user. Token-based access is the recommended way to subscribe a calendar app -- generate a per-user token in NetBox under **Profile -> API Tokens** and append it to the subscribe URL.
+
+See the [Calendar and iCal Feed](events/calendar-and-ical.md) page for the URL format and query parameters.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -9,13 +9,36 @@ edit_uri = "edit/main/docs/"
 docs_dir = "."
 nav = [
   { "Home" = "index.md" },
-  { "Outgoing Notifications" = "outgoing-notifications.md" },
+  { "Getting Started" = [
+    { "Installation" = "installation.md" },
+    { "Configuration" = "configuration.md" },
+    { "Permissions" = "permissions.md" },
+  ] },
+  { "Events" = [
+    { "Maintenance" = "events/maintenance.md" },
+    { "Outages" = "events/outage.md" },
+    { "Impact Tracking" = "events/impact.md" },
+    { "Calendar and iCal Feed" = "events/calendar-and-ical.md" },
+    { "Dashboard" = "events/dashboard.md" },
+  ] },
+  { "Outgoing Notifications" = [
+    { "Overview" = "outgoing-notifications.md" },
+    { "Templates" = "messaging/templates.md" },
+    { "Recipient Discovery" = "messaging/recipient-discovery.md" },
+    { "Approval Workflow" = "messaging/workflow.md" },
+  ] },
+  { "REST API" = "api/rest-api.md" },
   { "Automated Parsers" = [
     { "Using a parser" = "parsers.md" },
-    { "AWS SNS & Lambda" = "parsers_sns_lambda.md" },
+    { "AWS SNS and Lambda" = "parsers_sns_lambda.md" },
   ] },
   { "Integrations" = [
     { "AWS SES" = "integrations_aws_ses.md" },
+  ] },
+  { "Developer Guide" = [
+    { "Architecture" = "developer/architecture.md" },
+    { "Site and Location Resolvers" = "developer/resolvers.md" },
+    { "Template Extensions" = "developer/template-extensions.md" },
   ] },
   { "Contributing" = "contributing.md" },
   { "Changelog" = "changelog.md" },


### PR DESCRIPTION
Substantive expansion of the documentation site, generated by a per-plugin exploration pass that traced models, views, REST API, backends, and management commands. Covers user workflows, configuration references, REST API, and developer guides.

Drafted as PRs to land iteratively -- review piece by piece, edit / drop pages where the prose doesn't match operator reality, trim things better suited to code comments. The agent that drafted this had less context than you do; treat as a starting point.

ASCII-only output, no AI / Claude attribution. Conventional-commits PR title.