### PR TITLE
chore: migrate from bumpver to bump-my-version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "bumpver",
+    "bump-my-version",
     "pre-commit>=4.0.0",
     "pytest",
     "pytest-django>=4.5.0",
@@ -55,27 +55,29 @@ Documentation = "https://jsenecal.github.io/netbox-notices/"
 Source = "https://github.com/jsenecal/netbox-notices"
 Tracker = "https://github.com/jsenecal/netbox-notices/issues"
 
-[tool.bumpver]
+[tool.bumpversion]
 current_version = "1.1.2"
-version_pattern = "MAJOR.MINOR.PATCH"
-commit_message = "chore: bump version {old_version} -> {new_version}"
-tag_pattern = "vMAJOR.MINOR.PATCH"
 commit = true
 tag = true
-push = true
+tag_name = "v{new_version}"
+allow_dirty = false
+message = "chore: bump version {current_version} -> {new_version}"
+tag_message = "Release v{new_version}"
 
-[tool.bumpver.file_patterns]
-"pyproject.toml" = [
-    'current_version = "{version}"',
-    'version = "{version}"',
-]
-"notices/__init__.py" = [
-    '__version__ = "{version}"',
-]
-"CHANGELOG.md" = [
-    '## \[Unreleased\]',
-    '## \[{version}\] - {now:%Y-%m-%d}',
-]
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = 'current_version = "{current_version}"'
+replace = 'current_version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "notices/__init__.py"
+search = '__version__ = "{current_version}"'
+replace = '__version__ = "{new_version}"'
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
## Summary
Migrate this plugin's release tooling from bumpver to bump-my-version (the maintained bump2version fork).

## Why
bumpver's documented `tag_pattern` config is silently ignored by the tool -- the tag name is hardcoded to the bare version string in the source (`bumpver/vcs.py:242`: `vcs_api.tag(tag_name=new_version, ...)`). Verified against bumpver 2025.1131, the latest release as of 2025-07. This is why every recent release in our plugins has had to either store `current_version = "v0.X.Y"` (with v prefix, fragile `pep440_version` projection workaround) or accept that tags come out as bare `0.X.Y` and don't match the canonical `vMAJOR.MINOR.PATCH` convention.

bump-my-version exposes a real `tag_name = "v{new_version}"` template, removing the hack.

## Changes
- `pyproject.toml`: replace `[tool.bumpver]` + `[tool.bumpver.file_patterns]` block with `[tool.bumpversion]` + array of `[[tool.bumpversion.files]]` tables.
- `pyproject.toml`: replace `bumpver` with `bump-my-version` in `[project.optional-dependencies] dev`.

## Behavior changes
- **Tag name**: now `v{new_version}` via the proper config option (was bare `{new_version}` for most plugins, or `v{new_version}` only via the pep440_version hack on netbox-rir-manager).
- **Push**: bump-my-version does not auto-push. The release flow becomes `bump-my-version bump patch && git push --follow-tags` (bumpver's `push = true` auto-pushed).
- **CHANGELOG promotion**: dropped from the file replacements. bumpver's date-templated `## [{version}] - {now:%Y-%m-%d}` second pattern was already broken whenever a release wasn't on the same day as the previous one (the pattern only matches if the existing entry's date equals today). bump-my-version has the same fundamental limitation. Manual `[Unreleased] -> [X.Y.Z]` promotion before each bump is the realistic workflow.

## Testing
- [x] `bump-my-version bump patch --dry-run --allow-dirty` reports the correct version transition and proposes a `v{new_version}` tag.
- [x] Config-only change; no plugin code touched.

## Related
This is part of a fleet-wide migration across all 8 owned plugins. The companion PR will land in each.