### PR TITLE
ci: test against NetBox 4.6.x and drop 4.5.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
     name: Test (Python ${{ matrix.python }}, NetBox ${{ matrix.netbox }})
     runs-on: ubuntu-latest
     needs: lint
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write  # for Codecov OIDC upload
@@ -55,7 +56,11 @@ jobs:
       fail-fast: false
       matrix:
         python: ["3.12", "3.13", "3.14"]
-        netbox: ["4.5.8", "4.5.10"]
+        netbox:
+          # renovate: datasource=github-releases depName=netbox-community/netbox
+          - "4.5.10"
+          # renovate: datasource=github-releases depName=netbox-community/netbox
+          - "4.6.9"
     services:
       postgres:
         image: postgres:18-alpine
@@ -116,6 +121,12 @@ jobs:
 
           SECRET_KEY = "ci-only-secret-key-do-not-use-in-production-aaaaaaaaaaaaaaaaaaaa"
 
+          # NetBox refuses to save a v2 API token unless a pepper is configured;
+          # its own configuration_testing.py defines one for exactly this reason.
+          API_TOKEN_PEPPERS = {
+              1: "ci-only-test-pepper-do-not-use-in-production-aaaaaaaaaaaaaaaaaaaa",
+          }
+
           PLUGINS = ["notices"]
           PLUGINS_CONFIG = {"notices": {}}
           EOF_CFG
@@ -143,10 +154,10 @@ jobs:
           DJANGO_SETTINGS_MODULE: netbox.settings
           NETBOX_CONFIGURATION: netbox.configuration
         run: |
-          pytest tests/ -v --ignore=tests/test_ical_download.py --ignore=tests/test_ical_view.py --tb=short --cov=notices --cov-report=xml
+          pytest tests/ -v --tb=short --cov=notices --cov-report=xml
 
       - name: Upload coverage to Codecov
-        if: matrix.python == '3.13' && matrix.netbox == '4.5.10'
+        if: matrix.python == '3.13' && startsWith(matrix.netbox, '4.6.')
         continue-on-error: true
         uses: codecov/codecov-action@v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,14 @@ Releases prior to v1.1.x use the legacy `## VERSION (DATE)` heading style.
 
 - `notices/urls.py` rewritten to NetBox 4.x's `@register_model_view` / `get_model_urls()` pattern. Every URL name and path is unchanged except the deliberately unmounted ones (see Fixed); `tests/test_url_patterns.py` pins the rest.
 - The sent notifications changelog now resolves against `SentNotification`, so it 404s for a draft's pk instead of rendering it -- matching the detail view.
-- CI: switched dependency installation to `uv` for faster caching; activates the workspace `.venv` via `GITHUB_PATH` so plain `python` works from `/tmp/netbox/netbox`. Codecov upload uses OIDC (tokenless), gated to the 3.13 + 4.5.8 leg.
+- CI: switched dependency installation to `uv` for faster caching; activates the workspace `.venv` via `GITHUB_PATH` so plain `python` works from `/tmp/netbox/netbox`. Codecov upload uses OIDC (tokenless), gated to a single matrix leg.
 - `publish.yml`: switched build/publish jobs to `uv build` (was `python -m build`); pinned `actions/upload-artifact` and `actions/download-artifact` to v4 (matches canonical).
 - `pyproject.toml`: dropped `black`, `isort`, `flake8`, `pyproject-flake8`, `pip-tools`, `twine`, `Sphinx`, `watchdog`, `tox` from dev deps -- all superseded by ruff or moved to per-step CI installs. Removed legacy `[tool.flake8]` and `[tool.tox]` sections. Added `[docs]` extra (`zensical`). Expanded ruff selectors with `N`, `UP`, `S`, `B`, `A`, `DJ`, `PIE`. Several pre-existing issues (`B904`, `S701`, `S324`, `S308`, `A004`, `DJ001`) are temporarily globally ignored -- see TODO comment in `[tool.ruff.lint]`. Test per-file ignores added for `E402`, `F841`, `B011`. Added `extend-exclude` for `migrations/` and `parsers/`. Added bumpver `CHANGELOG.md` file pattern so the Unreleased section is promoted on every version bump.
 - `mkdocs.yml` (root) and `.github/workflows/mkdocs.yml` removed -- replaced by `docs/zensical.toml` + `.github/workflows/docs.yml`.
 - README trimmed from 542 lines to ~95 -- substantive content now lives in the published docs site.
+- CI test matrix now covers the newest release of each supported NetBox series -- 4.5.10 and 4.6.9 -- against Python 3.12, 3.13 and 3.14. NetBox 4.5.8 is dropped; 4.6.x is covered for the first time. Renovate keeps each matrix entry pinned inside its own minor series, and the test job gained a 30-minute timeout.
+- `tests/test_ical_download.py` and `tests/test_ical_view.py` run in CI again. They were excluded when the workflow was first written against NetBox 4.4; the rewritten suites finish in about 18 seconds. The workflow's NetBox configuration now also defines `API_TOKEN_PEPPERS` -- NetBox refuses to save a v2 API token without one, and its own `configuration_testing.py` supplies it, so the v2 token test passed locally but failed in CI.
+- Documented requirements corrected: `docs/installation.md` listed Python 3.10 and 3.11, which NetBox 4.5+ has never supported (the package already requires 3.12+). README's install section said NetBox 4.5.2+ where the rest of the page says 4.5.0+.
 
 ## 1.0.0 (2026-02-09)
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,11 @@ This plugin requires NetBox 4.5.0 or higher.
 | NetBox Version | Plugin Version |
 | -------------- | -------------- |
 | 4.5.x          | 1.x            |
+| 4.6.x          | 1.x            |
 
 ## Installing
 
-A working installation of Netbox 4.5.2+ is required - [see official documentation](https://netbox.readthedocs.io/en/stable/plugins/).
+A working installation of NetBox 4.5.0+ is required - [see official documentation](https://netbox.readthedocs.io/en/stable/plugins/).
 
 ### Package Installation
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,8 +6,8 @@ This page covers installing and enabling the `netbox-notices` plugin in an exist
 
 | Component | Required version |
 |-----------|------------------|
-| NetBox | 4.5.0 or later |
-| Python | 3.10, 3.11, 3.12, 3.13, or 3.14 |
+| NetBox | 4.5.0 or later (CI covers 4.5.x and 4.6.x) |
+| Python | 3.12, 3.13, or 3.14 |
 | PostgreSQL | Whatever your NetBox version requires |
 
 The plugin module name on disk is `notices` (note: not `netbox_notices`). The PyPI distribution name is `netbox-notices`.

--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,29 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
       "platformAutomerge": true
+    },
+    {
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["netbox-community/netbox"],
+      "matchCurrentValue": "/^4\\.5\\./",
+      "allowedVersions": "/^4\\.5\\./"
+    },
+    {
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["netbox-community/netbox"],
+      "matchCurrentValue": "/^4\\.6\\./",
+      "allowedVersions": "/^4\\.6\\./"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/ci\\.yml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>\\S+)\\s+- \"(?<currentValue>[^\"]+)\""
+      ],
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- The CI matrix covered two 4.5 patch releases and never exercised NetBox 4.6, despite `min_version = "4.5.0"` with no `max_version`. It now covers the newest release of each supported series: 4.5.10 and 4.6.9.
- Python stays 3.12 / 3.13 / 3.14. Both 4.5.10 and 4.6.9 declare `requires-python = ">=3.12"` and document exactly those three, so there was nothing older left to drop from the matrix -- only the docs were stale.
- Renovate now keeps each matrix entry pinned inside its own minor series, so the matrix stays current without a hand edit.

## Changes

- `.github/workflows/ci.yml`: matrix `["4.5.8", "4.5.10"]` -> `4.5.10` + `4.6.9`, one annotated entry per series (still 6 legs). Codecov gate matched the literal `4.5.10` and would have silently stopped uploading on the next bump -- now matches the series prefix, still exactly one uploading leg. Dropped the `--ignore` flags for the two iCal suites. Added `timeout-minutes: 30` to the test job.
- `renovate.json`: added the ci.yml customManager and per-series `packageRules` for `netbox-community/netbox`. Now identical to netbox-pathways' config.
- `docs/installation.md`: Python row `3.10, 3.11, 3.12, 3.13, 3.14` -> `3.12, 3.13, 3.14`; NetBox row notes the tested series.
- `README.md`: compatibility table gains a 4.6.x row; install section said "Netbox 4.5.2+" where the rest of the page says 4.5.0+.
- `CHANGELOG.md`: entries for the above, plus a correction to an existing `[Unreleased]` bullet that named the now-removed 4.5.8 codecov leg.

## Testing

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] Full suite passes locally: 683 passed against the devcontainer's NetBox 4.6.8, including both re-enabled iCal files
- [x] `test_ical_download.py` + `test_ical_view.py` in isolation: 26 passed in 18s (no hang)
- [x] ci.yml parses and expands to the 6 expected legs with a single codecov leg
- [x] Asserted the Renovate regex matches both annotated entries and that each packageRule claims exactly one
- [x] Docs updated (README, CHANGELOG, docs/installation.md)
- n/a New/changed behavior covered by tests -- no production code changed
- n/a Migration applied cleanly -- no schema change

Not verified locally: NetBox 4.5.10, and 4.6.9 specifically (local devcontainer is 4.6.8). Those need this CI run, which is why this is a draft.

## Related

Refs: none