### PR TITLE
ci: upload coverage with an explicit Codecov token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,12 +158,16 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python == '3.13' && startsWith(matrix.netbox, '4.6.')
-        continue-on-error: true
         uses: codecov/codecov-action@v7
         with:
-          use_oidc: true
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
-          fail_ci_if_error: false
+          # Fork PRs cannot read the secret, so a failed upload there is
+          # expected and must not redden the build. Everywhere else a
+          # rejected upload is a real problem: it silently stops the
+          # coverage gate from voting, which is how tokenless uploads
+          # rotted unnoticed.
+          fail_ci_if_error: ${{ github.event.pull_request.head.repo.fork != true }}
 
       - name: Check migrations
         env:


### PR DESCRIPTION
## Summary

- Codecov stopped accepting the tokenless OIDC upload. Uploads have been rejected server-side since early August, the repository fell inactive, and `codecov/patch` / `codecov/project` stopped voting on pull requests entirely.
- Authenticate with the repo upload token from the `CODECOV_TOKEN` secret instead of `use_oidc: true`.
- Make a rejected upload fail the job, so this cannot rot silently again. Fork pull requests keep the tolerant behavior, since they cannot read the secret.

## Why it went unnoticed

The upload step was `continue-on-error: true` with `fail_ci_if_error: false`, and the Codecov CLI exits 0 regardless -- it prints "Upload queued for processing complete" and the rejection happens later, server-side. So CI stayed green while the coverage gate was not voting at all.

## Changes

- `.github/workflows/ci.yml`: the Codecov upload step now passes `token: ${{ secrets.CODECOV_TOKEN }}` instead of `use_oidc: true`, drops `continue-on-error`, and sets `fail_ci_if_error` to `${{ github.event.pull_request.head.repo.fork != true }}`.

The `CODECOV_TOKEN` secret is set on this repository.

## Testing

- [x] `ruff check` passes -- no Python changed
- [x] `ruff format --check` passes -- no Python changed
- [x] YAML parses and the step resolves as intended
- [ ] `pytest` -- no test-affecting change; CI on this PR is itself the test
- [x] New/changed behavior covered by tests -- n/a, CI configuration
- [x] Migration applied cleanly (if schema changed) -- n/a
- [x] Docs updated -- n/a, no user-visible change (no CHANGELOG entry: CI-only)

This PR's own CI run is the verification. The upload step now runs against the token, and because this is not a fork PR, a rejection will fail the job rather than pass quietly. A green run here means uploads are being accepted again; a red one means the repository still needs reactivating on the Codecov side.

## Related

Same change as jsenecal/netbox-wdm#73, which covered netbox-wdm only.
