### PR TITLE
docs: repair the Zensical site and write the eight missing pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - "docs/**"
       - ".github/workflows/docs.yml"
+      # Pages pulled into the site with pymdownx.snippets
+      - "README.md"
+      - "CHANGELOG.md"
+      - "CONTRIBUTING.md"
+      - "integrations/aws-ses/README.md"
   workflow_dispatch:
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ venv.bak/
 
 # mkdocs documentation
 /site
+docs/site/
 
 # mypy
 .mypy_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Releases prior to v1.1.x use the legacy `## VERSION (DATE)` heading style.
 
 ## [Unreleased]
 
+### Fixed
+
+- The documentation site rendered `{% include-markdown "../README.md" %}` as
+  literal text on the home page, changelog, contributing and AWS SES pages.
+  That macro comes from `mkdocs-include-markdown-plugin`, which Zensical does
+  not load; those four pages now use `pymdownx.snippets` instead.
+
 ## [1.2.0] - 2026-08-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Releases prior to v1.1.x use the legacy `## VERSION (DATE)` heading style.
   literal text on the home page, changelog, contributing and AWS SES pages.
   That macro comes from `mkdocs-include-markdown-plugin`, which Zensical does
   not load; those four pages now use `pymdownx.snippets` instead.
+- README screenshots and its permissions link used repo-relative paths, so they
+  404'd on the documentation site and on PyPI. They are absolute URLs now.
 
 ## [1.2.0] - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Releases prior to v1.1.x use the legacy `## VERSION (DATE)` heading style.
   not load; those four pages now use `pymdownx.snippets` instead.
 - README screenshots and its permissions link used repo-relative paths, so they
   404'd on the documentation site and on PyPI. They are absolute URLs now.
+- Eight pages referenced by the documentation nav were never written, so the
+  sidebar linked to `.md` URLs that 404'd, along with six cross-page links.
+  Written: the REST API reference, the developer guide (architecture, resolvers,
+  template extensions), the messaging guide (templates, recipient discovery,
+  approval workflow) and the dashboard page.
 
 ## [1.2.0] - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Releases prior to v1.1.x use the legacy `## VERSION (DATE)` heading style.
   Written: the REST API reference, the developer guide (architecture, resolvers,
   template extensions), the messaging guide (templates, recipient discovery,
   approval workflow) and the dashboard page.
+- `outgoing-notifications.md` documented models under names they have never had
+  (`MessageTemplate`, `PreparedMessage`) and its integration examples used a
+  `prepared-messages/` endpoint that does not exist and a `ready` to `delivered`
+  transition the state machine rejects. It is now an overview over the three
+  messaging pages, with corrected examples.
 
 ## [1.2.0] - 2026-08-31
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The plugin does not directly provide an automated approach to ingesting provider
   - Bulk edit for maintenances, outages and notification templates (status and scheduling fields excluded -- use the quick actions and the reschedule view)
   - Bulk delete for maintenances, outages, notification templates and prepared notifications
   - Bulk import (CSV/JSON/YAML) for maintenances and outages; impacts are added afterwards
-  - Received and sent notifications have none: received ones are deletable one row at a time, sent ones are a read-only log deleted from the prepared notifications list. Prepared notification `status` is changed through the REST API -- see [permissions](docs/permissions.md).
+  - Received and sent notifications have none: received ones are deletable one row at a time, sent ones are a read-only log deleted from the prepared notifications list. Prepared notification `status` is changed through the REST API -- see [permissions](https://jsenecal.github.io/netbox-notices/permissions/).
 - Event timeline with status-specific icons and colors
 - Maintenance rescheduling with automatic status updates
 - Interactive calendar view with FullCalendar
@@ -478,7 +478,7 @@ A read-only view of PreparedNotifications that have been sent or delivered. This
 
 The maintenance detail view shows comprehensive information about a maintenance event including the event timeline, impacted objects, and received notifications.
 
-![Maintenance Event View](docs/img/maintenance_detail.png)
+![Maintenance Event View](https://raw.githubusercontent.com/jsenecal/netbox-notices/main/docs/img/maintenance_detail.png)
 
 **Key Features Shown:**
 - Operations dropdown with quick actions (Acknowledge, Reschedule, Mark In-Progress, Mark Completed, Cancel)
@@ -491,7 +491,7 @@ The maintenance detail view shows comprehensive information about a maintenance 
 
 The outage detail view tracks unplanned incidents with ETR (Estimated Time to Repair) and flexible status workflow.
 
-![Outage Event View](docs/img/outage_detail.png)
+![Outage Event View](https://raw.githubusercontent.com/jsenecal/netbox-notices/main/docs/img/outage_detail.png)
 
 **Key Features Shown:**
 - Outage-specific status workflow (Reported -> Investigating -> Identified -> Monitoring -> Resolved)
@@ -503,11 +503,11 @@ The outage detail view tracks unplanned incidents with ETR (Estimated Time to Re
 
 Interactive calendar view for visualizing maintenance and outage events with iCal subscription support.
 
-![Calendar View](docs/img/calendar_view.png)
+![Calendar View](https://raw.githubusercontent.com/jsenecal/netbox-notices/main/docs/img/calendar_view.png)
 
 Click any event to see a quick summary modal with key details:
 
-![Calendar Event Detail](docs/img/calendar_view_event_detail.png)
+![Calendar Event Detail](https://raw.githubusercontent.com/jsenecal/netbox-notices/main/docs/img/calendar_view_event_detail.png)
 
 **Key Features Shown:**
 - FullCalendar integration with month/week/day views
@@ -519,7 +519,7 @@ Click any event to see a quick summary modal with key details:
 
 A "Maintenance & Outage Events" widget appears on Provider detail pages, showing all events from that provider.
 
-![Provider Events](docs/img/provider_events.png)
+![Provider Events](https://raw.githubusercontent.com/jsenecal/netbox-notices/main/docs/img/provider_events.png)
 
 **Key Features Shown:**
 - All maintenance and outage events for the provider
@@ -531,7 +531,7 @@ A "Maintenance & Outage Events" widget appears on Provider detail pages, showing
 
 A "Maintenance & Outage History" widget automatically appears on the detail pages of any impacted NetBox objects (circuits, devices, sites, etc.). This provides quick visibility into events affecting specific infrastructure.
 
-![Object Event History](docs/img/object_event_history.png)
+![Object Event History](https://raw.githubusercontent.com/jsenecal/netbox-notices/main/docs/img/object_event_history.png)
 
 **Key Features Shown:**
 - Tabbed view separating maintenances and outages

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -1,0 +1,333 @@
+# REST API
+
+The plugin exposes seven endpoints under NetBox's plugin API namespace. They follow NetBox conventions throughout: token authentication, `limit`/`offset` pagination, `?brief=1` for compact representations, and the same filter grammar as core.
+
+The REST API is the primary interface. External parsers write events through it, and the outbound delivery loop reads and updates prepared notifications through it.
+
+## Base URL and authentication
+
+```
+/api/plugins/notices/
+```
+
+Every request needs a NetBox API token:
+
+```http
+GET /api/plugins/notices/maintenance/
+Authorization: Token 0123456789abcdef0123456789abcdef01234567
+```
+
+The browsable API is available at the same URLs in a logged-in browser session, and the OpenAPI schema NetBox generates at `/api/schema/` includes these endpoints.
+
+## Endpoints
+
+| Endpoint | Model | Methods |
+|---|---|---|
+| `maintenance/` | `Maintenance` | GET, POST, PUT, PATCH, DELETE |
+| `outage/` | `Outage` | GET, POST, PUT, PATCH, DELETE |
+| `impact/` | `Impact` | GET, POST, PUT, PATCH, DELETE |
+| `eventnotification/` | `EventNotification` | GET, POST, PUT, PATCH, DELETE |
+| `notification-templates/` | `NotificationTemplate` | GET, POST, PUT, PATCH, DELETE |
+| `prepared-notifications/` | `PreparedNotification` | GET, POST, PUT, PATCH, DELETE |
+| `sent-notifications/` | `SentNotification` | GET only |
+
+Note the inconsistency in naming: the event endpoints are singular (`maintenance`, `outage`, `impact`, `eventnotification`) and the messaging endpoints are plural and hyphenated. This is historical and is not going to change without a major version.
+
+## Maintenance
+
+```
+GET    /api/plugins/notices/maintenance/
+POST   /api/plugins/notices/maintenance/
+GET    /api/plugins/notices/maintenance/{id}/
+PATCH  /api/plugins/notices/maintenance/{id}/
+DELETE /api/plugins/notices/maintenance/{id}/
+```
+
+### Fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | string | Provider event ID. Required. |
+| `summary` | string | Required. |
+| `provider` | nested Provider | Write by PK. Required. |
+| `start` | datetime | Required. |
+| `end` | datetime | Required. Must not precede `start`. |
+| `status` | string | See [Maintenance Events](../events/maintenance.md). Required. |
+| `status_color` | string | Read-only. Badge colour for the current status. |
+| `original_timezone` | string | IANA timezone name from the provider notification. |
+| `internal_ticket` | string | Your change reference. |
+| `acknowledged` | boolean | |
+| `replaces` | integer | PK of the maintenance this one replaces. |
+| `impact` | string | Free-text impact description, distinct from `Impact` records. |
+| `comments` | string | |
+| `impact_count` | integer | Read-only count of linked `Impact` records. |
+| `tags`, `custom_fields`, `created`, `last_updated` | | Standard NetBox fields. |
+
+Setting `replaces` on creation moves the replaced maintenance to `RE-SCHEDULED` through a signal. Nothing in the request body reflects that; re-read the other event to see it.
+
+The response also carries `impacts` and `notifications` keys. Both are currently always `null`, whatever the record holds, because the serializer sources them from attributes that do not exist on the model. Do not build against them. To retrieve an event's impacts, query the impact endpoint by event, as shown below.
+
+### Filters
+
+`id`, `name`, `summary`, `status`, `provider_id`, `start`, `end`, `original_timezone`, `internal_ticket`, `acknowledged`, `impact`, `comments`.
+
+Plus relational filters:
+
+| Filter | Effect |
+|---|---|
+| `replaces_id` | Maintenances replacing a given event |
+| `has_replaces` | `true` for events that have been rescheduled, `false` for those that have not |
+| `site_id` | Maintenances impacting anything in a site |
+| `region_id` | Same, rolled up by region |
+| `site_group_id` | Same, rolled up by site group |
+| `location_id` | Same, by location |
+
+The four site filters traverse the cached `Impact.sites` and `Impact.locations` M2Ms. A target type with no registered resolver contributes nothing to them; see [Site and Location Resolvers](../developer/resolvers.md).
+
+`q` searches `name`, `summary`, `internal_ticket` and the free-text `impact` field.
+
+### Example
+
+```http
+POST /api/plugins/notices/maintenance/
+Authorization: Token YOUR_API_TOKEN
+Content-Type: application/json
+
+{
+  "name": "PWIC-12345",
+  "summary": "Planned fibre splice, Route 7",
+  "provider": 7,
+  "status": "CONFIRMED",
+  "start": "2026-09-14T02:00:00Z",
+  "end": "2026-09-14T06:00:00Z",
+  "original_timezone": "America/Toronto",
+  "internal_ticket": "CHG-4471"
+}
+```
+
+## Outage
+
+```
+GET    /api/plugins/notices/outage/
+POST   /api/plugins/notices/outage/
+GET    /api/plugins/notices/outage/{id}/
+PATCH  /api/plugins/notices/outage/{id}/
+DELETE /api/plugins/notices/outage/{id}/
+```
+
+Same shape as Maintenance, with `end` optional and three extra fields: `reported_at`, `estimated_time_to_repair`, and a status from the outage set. `end` becomes required once `status` is `RESOLVED`.
+
+Filters match Maintenance minus the reschedule ones, plus `reported_at` and `estimated_time_to_repair`. The four site filters behave identically.
+
+See [Outage Events](../events/outage.md) for worked examples.
+
+## Impact
+
+```
+GET    /api/plugins/notices/impact/
+POST   /api/plugins/notices/impact/
+GET    /api/plugins/notices/impact/{id}/
+PATCH  /api/plugins/notices/impact/{id}/
+DELETE /api/plugins/notices/impact/{id}/
+```
+
+Both ends of an `Impact` are generic foreign keys, so writes take a content type and an object ID for each.
+
+| Field | Type | Notes |
+|---|---|---|
+| `event_content_type` | integer | ContentType PK. Limited to `notices.maintenance` and `notices.outage`. |
+| `event_object_id` | integer | PK of the event. |
+| `event` | object | Read-only. Nested maintenance or outage, whichever applies. |
+| `target_content_type` | integer | ContentType PK. Must be in `allowed_content_types`. |
+| `target_object_id` | integer | PK of the affected object. |
+| `target` | object | Read-only. Full circuit representation for circuits, a basic `{id, name, type}` otherwise. |
+| `impact` | string | `NO-IMPACT`, `REDUCED-REDUNDANCY`, `DEGRADED` or `OUTAGE`. Nullable. |
+
+The write fields take numeric ContentType PKs, which differ between deployments. Look them up first:
+
+```http
+GET /api/extras/content-types/?app_label=notices&model=maintenance
+GET /api/extras/content-types/?app_label=dcim&model=device
+```
+
+Filters accept the dotted form instead, which is easier to use by hand. `event_content_type` and `target_content_type` are `ContentTypeFilter` fields, so this works:
+
+```http
+GET /api/plugins/notices/impact/?event_content_type=notices.maintenance&event_object_id=42
+```
+
+That is the supported way to list an event's impacts, given that the `impacts` key on the event serializers is not usable.
+
+Other filters: `id`, `event_object_id`, `target_object_id`, `impact`, `site_id`, `region_id`, `site_group_id`, `location_id`.
+
+Three validation rules apply on write, all from `Impact.clean()`:
+
+1. `target_content_type` must appear in `allowed_content_types`.
+2. `event_content_type` must be `notices.maintenance` or `notices.outage`.
+3. The parent event must not be closed. Impacts cannot be created or changed on a maintenance in `COMPLETED` or `CANCELLED`, or an outage in `RESOLVED`.
+
+A `unique_together` constraint on the four generic FK columns prevents the same event being linked to the same target twice.
+
+## Event notifications
+
+```
+GET    /api/plugins/notices/eventnotification/
+POST   /api/plugins/notices/eventnotification/
+GET    /api/plugins/notices/eventnotification/{id}/
+DELETE /api/plugins/notices/eventnotification/{id}/
+```
+
+Stores the provider email that produced an event. This is the endpoint a parser posts to after creating the event itself.
+
+| Field | Type | Notes |
+|---|---|---|
+| `event_content_type` | integer | ContentType PK, maintenance or outage. |
+| `event_object_id` | integer | PK of the event. |
+| `event` | object | Read-only nested event. |
+| `subject` | string | Max 100 characters. |
+| `email_from` | email | |
+| `email_received` | datetime | |
+| `email_body` | string | Rendered on the detail page after sanitisation. |
+
+The model also has a binary `email` field holding the raw MIME message. It is not exposed through the serializer.
+
+Filters: `id`, `event_content_type`, `event_object_id`, `subject`, `email_from`, `email_received`, `email_body`. `q` searches subject, body and sender.
+
+## Notification templates
+
+```
+GET    /api/plugins/notices/notification-templates/
+POST   /api/plugins/notices/notification-templates/
+GET    /api/plugins/notices/notification-templates/{id}/
+PATCH  /api/plugins/notices/notification-templates/{id}/
+DELETE /api/plugins/notices/notification-templates/{id}/
+```
+
+Field reference is in [Templates](../messaging/templates.md). Two API-specific behaviours:
+
+**`headers_template` accepts YAML.** Send a YAML string and the serializer parses it into the stored JSON object. Sending a JSON object directly also works.
+
+```json
+{
+  "headers_template": "X-Event-Reference: \"{{ maintenance.name }}\"\nReply-To: \"noc@example.com\""
+}
+```
+
+**`scopes` is writable inline.** Scopes are nested in the template payload rather than having an endpoint of their own, and `content_type` there is the model name as a slug, not a PK:
+
+```json
+{
+  "name": "Customer maintenance notice",
+  "slug": "customer-maintenance",
+  "event_type": "maintenance",
+  "granularity": "per_tenant",
+  "subject_template": "[{{ maintenance.status }}] Maintenance {{ maintenance.name }}",
+  "body_template": "...",
+  "scopes": [
+    {"content_type": "tenant", "object_id": null, "event_type": "maintenance", "weight": 1500}
+  ]
+}
+```
+
+A PATCH that includes `scopes` deletes every existing scope on the template and recreates the list from the payload. It is a replace, not a merge, so partial scope updates are not possible. Omit the key entirely to leave scopes alone.
+
+`contact_roles` behaves the same way: supplying it replaces the whole set.
+
+Filters: `id`, `name`, `slug`, `event_type`, `granularity`, `is_base_template`. `event_type` and `granularity` accept multiple values. `q` searches name, slug and description.
+
+## Prepared notifications
+
+```
+GET    /api/plugins/notices/prepared-notifications/
+POST   /api/plugins/notices/prepared-notifications/
+GET    /api/plugins/notices/prepared-notifications/{id}/
+PATCH  /api/plugins/notices/prepared-notifications/{id}/
+DELETE /api/plugins/notices/prepared-notifications/{id}/
+```
+
+This endpoint is the outbound queue, and status changes here are the only way to drive the state machine. The web UI does not expose the field.
+
+| Field | Type | Notes |
+|---|---|---|
+| `template` | nested | Read-only. Write with `template_id`. |
+| `template_id` | integer | Write-only. Required on create. |
+| `event_content_type`, `event_id` | integer | Optional link to a maintenance or outage. |
+| `status` | string | See below. |
+| `contacts` | nested list | Read-only. Write with `contact_ids`. |
+| `contact_ids` | list of integers | Write-only. |
+| `recipients` | JSON | Read-only. Snapshot taken at approval. |
+| `subject`, `body_text`, `body_html`, `headers`, `css`, `ical_content` | | Rendered content. |
+| `approved_by`, `approved_at`, `sent_at`, `delivered_at`, `viewed_at` | | Read-only. Set by the state machine. |
+| `message` | string | Write-only. Creates a journal entry for the transition. |
+| `timestamp` | datetime | Write-only. Real time of the transition. |
+
+### Status rules
+
+A create must use `draft`. Any other value is rejected:
+
+```json
+{"status": ["A notification is always created as 'draft'. Create it first, then PATCH it to 'ready'."]}
+```
+
+An update must follow the transition graph. `draft` to `ready` to `sent` to `delivered`, with `sent` also able to reach `failed`, and `failed` able to return to `ready`. An invalid move names the valid ones:
+
+```json
+{"status": ["Cannot transition from 'draft' to 'sent'. Valid: ready"]}
+```
+
+The `timestamp` field lets a batching delivery system record when something actually happened rather than when it got round to reporting it. It cannot be in the future, `sent_at` cannot precede `approved_at`, and `delivered_at` cannot precede `sent_at`.
+
+Read `recipients`, not `contacts`, when delivering. The full rationale, side effects and a polling loop are in [Approval Workflow](../messaging/workflow.md).
+
+Filters: `id`, `status`, `template_id`. `status` accepts multiple values. `q` searches subject and body text.
+
+## Sent notifications
+
+```
+GET /api/plugins/notices/sent-notifications/
+GET /api/plugins/notices/sent-notifications/{id}/
+```
+
+A read-only view of the same table, filtered by its manager to `sent` and `delivered`. Every field is read-only and only `GET`, `HEAD` and `OPTIONS` are accepted. It exists so an audit consumer can read the delivery log without any possibility of writing to it.
+
+## iCal feed
+
+The calendar feed is not part of the REST API and is not a DRF endpoint, but it accepts the same tokens:
+
+```
+GET /plugins/notices/ical/maintenances.ics
+```
+
+It supports a `token` query parameter in addition to the `Authorization` header, because calendar clients cannot set headers. It also honours ETag and `If-None-Match`. See [Calendar and iCal Feed](../events/calendar-and-ical.md) for parameters and caching behaviour.
+
+## GraphQL
+
+Read-only GraphQL queries are registered for maintenance, outage, impact, event notification, notification template and prepared notification, in both single and list form, at NetBox's usual `/graphql/` endpoint.
+
+```graphql
+query {
+  maintenance_list(filters: {status: "CONFIRMED"}) {
+    id
+    name
+    provider { name }
+    start
+    end
+  }
+}
+```
+
+There are no GraphQL mutations. Writes go through REST.
+
+## Permissions
+
+Endpoints enforce the standard NetBox model permissions, `notices.view_maintenance`, `notices.add_impact` and so on, including object-level constraints. `sent-notifications/` checks `notices.view_preparednotification`, since the proxy shares the underlying model.
+
+See [Permissions](../permissions.md) for the full matrix and recommended role bindings.
+
+## See also
+
+- [Maintenance Events](../events/maintenance.md)
+- [Outage Events](../events/outage.md)
+- [Impact Tracking](../events/impact.md)
+- [Approval Workflow](../messaging/workflow.md)
+- [Using a parser](../parsers.md)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,1 @@
-{%
-  include-markdown "../CHANGELOG.md"
-%}
+--8<-- "CHANGELOG.md"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,3 +1,1 @@
-{%
-  include-markdown "../CONTRIBUTING.md"
-%}
+--8<-- "CONTRIBUTING.md"

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -1,0 +1,151 @@
+# Architecture
+
+This page describes how netbox-notices is put together: the module layout, the model layer, and the NetBox registries the plugin hooks into. It is aimed at people modifying the plugin or extending it from another plugin.
+
+## Two halves
+
+The plugin does two separate jobs that share a data model but are otherwise independent.
+
+**Event tracking.** A provider announces a maintenance window or an outage. That becomes a `Maintenance` or `Outage` record, plus one `Impact` row per affected NetBox object, plus the raw provider email as an `EventNotification`. Everything here is inbound.
+
+**Outgoing notifications.** Your organisation tells its own customers about that event. A `NotificationTemplate` is rendered against the event into a `PreparedNotification`, which an external delivery system collects over the REST API. Everything here is outbound.
+
+The plugin never sends mail in either direction. Inbound parsing is done by external parsers that POST to the REST API (see [Using a parser](../parsers.md)); outbound delivery is done by an external system that polls the API (see [Approval Workflow](../messaging/workflow.md)). What lives here is the storage, validation, rendering, and state tracking in between.
+
+## Module map
+
+```
+notices/
+  __init__.py           NoticesConfig(PluginConfig); default_settings; ready() imports
+                        checks, resolvers, signals, widgets so their registries populate
+  constants.py          DEFAULT_ALLOWED_CONTENT_TYPES
+  choices.py            Every ChoiceSet: statuses, impact levels, timezones,
+                        template event types, granularity, body format
+  utils.py              get_allowed_content_types()
+  checks.py             Django system check notices.W001 (resolver coverage)
+
+  models/
+    events.py           BaseEvent (abstract), Maintenance, Outage, Impact,
+                        EventNotification
+    messaging.py        NotificationTemplate, TemplateScope, PreparedNotification,
+                        SentNotification (proxy)
+
+  resolvers.py          Site/Location resolver registry for Impact targets
+  signals.py            Reschedule side effect; Impact site cache maintenance
+  validators.py         PreparedNotificationStateMachine and VALID_TRANSITIONS
+
+  services/
+    template_matching.py    Scope matching and weighted merge
+    template_renderer.py    Jinja environment, custom filters, context builder
+    recipient_discovery.py  Tenant -> ContactAssignment -> Contact traversal
+    ical_generation.py      BCOP iCal bodies for notification attachments
+
+  api/
+    serializers/        events.py, messaging.py
+    views/              events.py, messaging.py
+    urls.py             NetBoxRouter registrations
+
+  graphql/              Strawberry types, filters, schema
+  filtersets.py         List and API filtering
+  forms.py              Model, filter, bulk-edit and import forms
+  tables.py             django-tables2 definitions
+  views.py              Dashboard, model views, quick actions, calendar, iCal feed
+  urls.py               Mounts views registered with @register_model_view
+  navigation.py         Plugin menu
+  search.py             Global search indexes
+  widgets.py            NetBox dashboard widget
+  template_content.py   PluginTemplateExtension classes injected into core pages
+  templatetags/         sanitize_html filter for provider email bodies
+  ical_utils.py         Feed generation, status mapping, ETag calculation
+  timeline_utils.py     ObjectChange categorisation for detail-page timelines
+  management/commands/  refresh_impact_sites
+```
+
+## Model layer
+
+### Events
+
+`BaseEvent` is an abstract `NetBoxModel` holding what a maintenance and an outage have in common: `name`, `summary`, `provider`, `start`, `original_timezone`, `internal_ticket`, `acknowledged`, `comments`, and a free-text `impact` description. Its `clean()` enforces one rule, that `end` is not before `start`, and it reads `end` with `getattr` because the field is defined by the subclass.
+
+`Maintenance` adds a required `end`, a `status` from `MaintenanceTypeChoices`, and `replaces`, a self-referencing FK used for rescheduling.
+
+`Outage` adds `reported_at`, an optional `end`, `estimated_time_to_repair`, and a `status` from `OutageStatusChoices`. Its `clean()` requires `end` once the status is `RESOLVED`.
+
+Both subclasses declare `provider` again rather than inheriting it, because `BaseEvent` uses a `%(class)s_events` related name and `Maintenance` needs the plain `maintenance` accessor for backward compatibility.
+
+### Impact
+
+`Impact` is the join between an event and an affected object, and it is generic on both ends:
+
+- `event_content_type` / `event_object_id` / `event`, restricted by `limit_choices_to` to `notices.maintenance` and `notices.outage`.
+- `target_content_type` / `target_object_id` / `target`, restricted at validation time to `allowed_content_types`.
+
+A generic FK cannot be joined against, so filtering "every maintenance affecting site X" cannot walk `target` in SQL. `Impact` therefore carries two cached M2M fields, `sites` and `locations`, populated from `target` by `refresh_sites()` through the [resolver registry](resolvers.md). The list filters on `Maintenance`, `Outage` and `Impact` traverse those caches, which is what makes region and site-group rollups possible.
+
+Two `Impact` methods exist to keep NetBox from breaking on edge cases:
+
+- `to_objectchange()` reassigns the change's `related_object` to the parent event, so impact edits show up in the event's changelog rather than nowhere.
+- `get_absolute_url()` must never raise, because NetBox calls it from table columns and serializers where one bad row would take down a whole list page. A generic FK has no database-level cascade, so an impact can outlive its event; the method falls back to the parent type's list view, then to the dashboard.
+
+`Impact` has no list or detail view. Its changelog and journal routes are filtered out in `urls.py` because both render through `generic/object.html`, which builds a breadcrumb from the model's list URL.
+
+### Messaging
+
+`NotificationTemplate` holds the Jinja sources plus the matching and recipient configuration. `TemplateScope` attaches a template to a NetBox object with a weight, in the manner of config contexts. `PreparedNotification` is a rendered snapshot with a status. `SentNotification` is a proxy over `PreparedNotification` whose manager filters to `sent` and `delivered`, which is how the "Sent" list stays read-only without a second table.
+
+## Registries
+
+The plugin populates several NetBox registries. `NoticesConfig.ready()` imports `checks`, `resolvers`, `signals` and `widgets` purely for their import side effects; the rest are discovered by NetBox from conventional module names.
+
+| Registry | Module | Populated by |
+|---|---|---|
+| Site/location resolvers | `resolvers.py` | `@register_site_resolver`, `@register_location_resolver` |
+| Django system checks | `checks.py` | `@register()` |
+| Signal handlers | `signals.py` | `@receiver` |
+| Dashboard widgets | `widgets.py` | `@register_widget` |
+| Global search | `search.py` | `@register_search` |
+| Template extensions | `template_content.py` | module-level `template_extensions` list |
+| Model views | `views.py` | `@register_model_view`, mounted by `urls.py` |
+| REST API | `api/urls.py` | `NetBoxRouter.register` |
+| GraphQL | `graphql/schema.py` | `graphql_schema` on the PluginConfig |
+
+`urls.py` only mounts; every view is registered with `@register_model_view` in `views.py`. Each model needs two entries, one for its list-level routes and one for its per-object routes. Changelog and journal views register themselves through `PluginConfig.ready()`.
+
+## Signals
+
+`signals.py` carries two unrelated concerns.
+
+The first is the reschedule side effect: when a `Maintenance` is created with `replaces` set, the replaced event is snapshotted and moved to `RE-SCHEDULED`. The snapshot is what makes the transition appear in the changelog.
+
+The second is impact cache maintenance. Each handler answers one question: given that this upstream object changed, which impacts need their `sites` and `locations` rebuilt? Handlers exist for `Impact` itself, `Site`, `Device`, `PowerFeed`, `PowerPanel`, `Circuit` and `CircuitTermination`. The `PowerPanel` and `CircuitTermination` handlers exist because those models sit between the target and its site, so a change there is invisible to a handler on the target itself.
+
+This handler list maps one to one onto the default resolver registry. Registering a resolver for a new content type without adding the matching signals leaves the cache to drift silently. There is no check for that case; `notices.W001` only catches a missing resolver, not missing signals.
+
+## Services
+
+The four modules under `services/` are plain classes with no Django view or model dependencies, which makes them callable from a script, a management command, or another plugin.
+
+`TemplateMatchingService` scores templates against a context of event, tenant and provider, and `merge_templates()` folds a scored list into one configuration dict with field-level precedence. See [Templates](../messaging/templates.md).
+
+`TemplateRenderer` owns a Jinja `Environment` with `autoescape=False` and two custom filters, `ical_datetime` and `markdown`. Its `build_context()` classmethod assembles the variables a template sees.
+
+`RecipientDiscoveryService` walks impacts to tenants to contact assignments. See [Recipient Discovery](../messaging/recipient-discovery.md).
+
+`ical_generation` builds BCOP-compliant iCal bodies for notification attachments. It is distinct from `ical_utils.py`, which serves the subscribable calendar feed.
+
+## Request paths worth knowing
+
+**The iCal feed** (`MaintenanceICalView`) is not a model view and is mounted directly at `ical/maintenances.ics`. It accepts three authentication methods, in order: a `token` query parameter, an `Authorization` header, then session auth. The query-parameter path exists because calendar clients cannot set headers, and it validates both v1 and v2 NetBox token formats by hand. The view computes an ETag from the result count, the newest `last_updated`, and the query parameters, so feed readers polling every fifteen minutes mostly get a 304.
+
+**The dashboard** (`DashboardView`) is a plain `View`, not an `ObjectListView`, and runs a fixed set of aggregate queries. See [Dashboard](../events/dashboard.md).
+
+**Status changes on a prepared notification** are REST-API-only. The web UI deliberately does not expose the field, because a direct write would skip the recipient snapshot and the approval stamps that the state machine applies. See [Approval Workflow](../messaging/workflow.md).
+
+## Extending from another plugin
+
+Two extension points are supported and covered on their own pages:
+
+- Register a site and location resolver so a new target type becomes filterable. See [Site and Location Resolvers](resolvers.md).
+- Add your content type to `allowed_content_types` so impacts can point at it, which also gives it an event history panel. See [Template Extensions](template-extensions.md).
+
+Both need a NetBox restart to take effect, since the resolver registry and the generated template extension classes are built at import time.

--- a/docs/developer/resolvers.md
+++ b/docs/developer/resolvers.md
@@ -1,0 +1,175 @@
+# Site and Location Resolvers
+
+`Impact` points at its target with a `GenericForeignKey`, which SQL cannot join against. To make "show me every maintenance affecting anything in site X" a real query, `Impact` caches the target's site and location membership on two M2M fields, `sites` and `locations`. The resolver registry in `notices/resolvers.py` is where those values come from.
+
+A resolver is a small function that answers one question for one content type: given an instance of this model, which `Site` (or `Location`) primary keys does it belong to?
+
+## When you need one
+
+You need to register a resolver whenever you add a content type to `allowed_content_types`:
+
+```python
+PLUGINS_CONFIG = {
+    "notices": {
+        "allowed_content_types": [
+            "circuits.Circuit",
+            "dcim.Device",
+            "dcim.PowerFeed",
+            "dcim.Site",
+            "virtualization.VirtualMachine",  # needs a resolver
+        ],
+    },
+}
+```
+
+Without one, impacts targeting that type still save and still display. They just have empty `sites` and `locations`, so they never appear in the `site_id`, `region_id`, `site_group_id` or `location_id` filters. Nothing errors; the rows are simply invisible to site-scoped queries.
+
+The plugin emits a startup warning for this case. `notices.checks.check_resolver_coverage` compares `allowed_content_types` against the registered site resolvers and raises `notices.W001` for each type with no resolver:
+
+```
+System check identified some issues:
+
+WARNINGS:
+?: (notices.W001) No site resolver registered for allowed content type
+'virtualization.VirtualMachine'.
+    HINT: Impacts targeting this type will have empty Impact.sites and won't
+    appear in site/region/location filters. Register one via
+    notices.resolvers.register_site_resolver, and add a matching signal handler
+    in notices.signals so the cache stays fresh when the target's site changes.
+```
+
+The check covers site resolvers only. A missing location resolver is silent, which is intentional: plenty of models have no meaningful location.
+
+## Built-in resolvers
+
+The four types in `DEFAULT_ALLOWED_CONTENT_TYPES` ship with resolvers.
+
+| Content type | Sites | Locations |
+|---|---|---|
+| `dcim.site` | The site itself | None. Locations live underneath sites. |
+| `dcim.device` | `device.site_id` | `device.location_id` if set |
+| `dcim.powerfeed` | `feed.power_panel.site_id` | The panel's `location_id` if set |
+| `circuits.circuit` | `_site_id` of each termination | `_location_id` of each termination |
+
+The circuit resolver is the one worth reading. A circuit can span two sites, one per termination, and a termination may resolve to a Site, Location, Region, SiteGroup or ProviderNetwork. NetBox 4.5 and later denormalise the result onto `CircuitTermination._site_id` and `._location_id`, so the resolver reads those rather than walking the generic termination FK itself.
+
+## Registering a resolver
+
+Use the decorators. The key is a dotted `app_label.modelname` string, matched case-insensitively.
+
+```python
+from notices.resolvers import register_location_resolver, register_site_resolver
+
+
+@register_site_resolver("virtualization.virtualmachine")
+def _vm_sites(vm):
+    if vm.site_id:
+        return (vm.site_id,)
+    if vm.cluster_id and vm.cluster.site_id:
+        return (vm.cluster.site_id,)
+    return ()
+
+
+@register_location_resolver("virtualization.virtualmachine")
+def _vm_locations(vm):
+    return (vm.location_id,) if vm.location_id else ()
+```
+
+The contract is forgiving. A resolver receives the target instance and returns an iterable of PKs. Returning `None`, an empty iterable, or an iterable containing `None` or `0` is all fine, because the caller deduplicates and drops falsy values. That means the common case can be a one-liner:
+
+```python
+@register_site_resolver("dcim.device")
+def _device_sites(device):
+    return (device.site_id,)
+```
+
+Registering twice for the same key raises `ValueError` rather than overwriting. Silent overrides caused by import ordering are harder to debug than a loud failure. `unregister_resolvers("app.model")` removes both resolvers for a key and is mainly there for tests.
+
+### Where to put the registration
+
+The module has to be imported for the decorators to run. From another plugin, the `ready()` hook of your `PluginConfig` is the right place:
+
+```python
+class MyPluginConfig(PluginConfig):
+    def ready(self):
+        super().ready()
+        from . import notices_resolvers  # noqa: F401
+```
+
+Registration happens at import time, so a NetBox restart is needed for a new resolver to take effect.
+
+### Performance
+
+Resolvers run inside `Impact.refresh_sites()`, which is called from signal handlers. On a bulk import that is once per impact row, so a resolver that issues queries multiplies quickly.
+
+Prefer the `*_id` attribute over the related object. `device.site_id` is an attribute read; `device.site.pk` is a database round trip. Where you have to traverse a relation, as the power feed resolver does through its panel, accept the one query and stop there rather than chaining further.
+
+## Keeping the cache fresh
+
+Registering a resolver is half the job. The cache also has to be invalidated when something upstream changes, and that is what `notices/signals.py` does.
+
+`Impact.refresh_sites()` runs on:
+
+1. Any `Impact` save, via `post_save`.
+2. A change to a target object, via `post_save` handlers on `Site`, `Device`, `PowerFeed`, `Circuit`.
+3. A change to a model *between* the target and its site. `PowerPanel` and `CircuitTermination` both have handlers for this reason: a panel moving to a new site changes the site of every feed on it, and that is invisible to a handler watching only `PowerFeed`.
+4. An explicit run of `manage.py refresh_impact_sites`.
+
+So a new resolver needs matching signal handlers for every model whose change would alter the answer:
+
+```python
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from virtualization.models import VirtualMachine
+
+from notices.signals import _refresh_impacts_for
+
+
+@receiver(post_save, sender=VirtualMachine)
+def _vm_changed(sender, instance, **kwargs):
+    _refresh_impacts_for(instance)
+```
+
+If the resolver falls back to `vm.cluster.site_id`, a handler on `Cluster` is needed too, following the `PowerPanel` pattern: find the affected VMs, then refresh the impacts pointing at them.
+
+Nothing detects a missing signal handler. `notices.W001` checks that a resolver exists, not that the cache stays correct. A cache that drifts is quiet, and shows up as a maintenance that stops appearing under a site filter after the device moved.
+
+## Rebuilding the cache
+
+`refresh_impact_sites` recomputes `sites` and `locations` for every impact:
+
+```bash
+python manage.py refresh_impact_sites
+```
+
+Limit it to specific rows with a repeatable `--impact-id`:
+
+```bash
+python manage.py refresh_impact_sites --impact-id 42 --impact-id 43
+```
+
+Run it after a bulk import or a script that bypassed signals, after adding a resolver where you want prior impacts backfilled, or when you suspect drift. It reports progress every hundred rows and is safe to re-run; `refresh_sites()` uses `.set()`, so membership is replaced rather than appended to.
+
+## Calling the registry directly
+
+Both lookups are available as functions, which is useful in a shell when working out why a filter is empty:
+
+```python
+from django.contrib.contenttypes.models import ContentType
+
+from notices.resolvers import resolve_locations_for, resolve_sites_for
+
+ct = ContentType.objects.get(app_label="dcim", model="device")
+device = Device.objects.get(name="edge-01")
+
+resolve_sites_for(ct, device)      # {12}
+resolve_locations_for(ct, device)  # set()
+```
+
+Both return a deduplicated set of non-falsy PKs, and both return an empty set for an unregistered content type rather than raising. That is the behaviour that makes a missing resolver quiet, and the reason the system check exists.
+
+## See also
+
+- [Impact Tracking](../events/impact.md) for the model and its validation rules
+- [Configuration](../configuration.md) for `allowed_content_types`
+- [Architecture](architecture.md) for how the registry fits into the plugin

--- a/docs/developer/template-extensions.md
+++ b/docs/developer/template-extensions.md
@@ -1,0 +1,130 @@
+# Template Extensions
+
+The plugin injects panels into pages that belong to NetBox core, so a maintenance shows up where an engineer is already looking rather than only under the Notices menu. All of it lives in `notices/template_content.py`, using NetBox's `PluginTemplateExtension` API.
+
+Three things get injected:
+
+- An event history panel on every object type in `allowed_content_types`.
+- An events panel on the Provider detail page.
+- A dashboard widget listing upcoming maintenances.
+
+## Event history panel
+
+Every detail page for an allowed content type gets a card in the right-hand column showing the maintenances and outages that impact that object. The card renders as two tabs with counts, and each tab falls back to "No maintenances in this period" when empty. If there are no events at all in the window, the extension returns an empty string and no card is drawn.
+
+### Generated classes
+
+The interesting part is that these classes do not exist in the source. `allowed_content_types` is a runtime setting, so the extension classes are built from it at import time:
+
+```python
+def _create_event_history_extensions():
+    allowed_types = get_allowed_content_types()
+    extensions = []
+
+    def right_page_method(self):
+        return render_event_history(self.context["object"])
+
+    for content_type_str in allowed_types:
+        app_label, model = content_type_str.lower().split(".")
+        extension_class = type(
+            f"{model.capitalize()}EventHistory",
+            (PluginTemplateExtension,),
+            {"models": [f"{app_label}.{model}"], "right_page": right_page_method},
+        )
+        extensions.append(extension_class)
+
+    return extensions
+
+
+template_extensions = _create_event_history_extensions() + [ProviderEventsExtension]
+```
+
+Two consequences follow.
+
+Adding a content type to `allowed_content_types` gives it an event history panel with no further work. That is separate from the [resolver](resolvers.md) requirement: the panel works without a resolver, because it queries `Impact` by content type and object ID directly rather than through the site cache. A resolver is only needed for the site-scoped filters.
+
+The classes are built when the module is imported, so a change to `allowed_content_types` needs a NetBox restart before the new panel appears.
+
+### Which events are shown
+
+`render_event_history(obj)` looks up impacts pointing at the object, then keeps an event if any of these hold:
+
+- It starts after the cutoff, which is now minus `event_history_days`.
+- It has an `end` in the future.
+- It has no `end` at all, which is the open-ended outage case.
+
+The default window is 30 days, configurable per deployment:
+
+```python
+PLUGINS_CONFIG = {
+    "notices": {
+        "event_history_days": 90,
+    },
+}
+```
+
+The setting is read from `netbox.config.get_config()` on every render rather than cached at import, so a change to it takes effect without a restart. This is the opposite of the class generation above, which is why changing `event_history_days` is cheap and changing `allowed_content_types` is not.
+
+Filtering happens in Python, not SQL. `render_event_history` pulls every impact for the object and then walks the list. That is fine for the row counts a single device accumulates, but it is worth knowing before pointing it at something with thousands of impacts.
+
+## Provider events panel
+
+`ProviderEventsExtension` targets `circuits.provider` and is a plain class, since there is only one of it. It shows every maintenance and outage linked to the provider through the `provider` FK, not through impacts, using the same `event_history_days` window expressed as a single ORM filter:
+
+```python
+time_filter = Q(start__gte=cutoff_date) | Q(end__gte=timezone.now()) | Q(end__isnull=True)
+```
+
+Events are ordered newest first and prefetch their impacts for the count column.
+
+## Dashboard widget
+
+`notices/widgets.py` registers `UpcomingMaintenanceWidget` with NetBox's dashboard. Users add it from the NetBox home page; it is not enabled by default.
+
+The widget lists maintenances in any active status, `TENTATIVE`, `CONFIRMED`, `IN-PROCESS`, `RE-SCHEDULED` or `UNKNOWN`, annotated with an impact count. It has no date bound, so it shows past events that were never closed out as well as upcoming ones. Default size is 8 by 3.
+
+This is separate from the plugin's own [dashboard](../events/dashboard.md), which is a full page under the Notices menu.
+
+## Sanitising provider email
+
+Received notifications store the provider's raw email, and the detail page renders the HTML body. `notices/templatetags/notices_filters.py` provides the `sanitize_html` filter used for that.
+
+It runs `nh3` with NetBox's own allow-lists, with one change: the `class` attribute is stripped.
+
+```python
+EMAIL_ALLOWED_ATTRIBUTES = {
+    tag: attributes - {"class"} for tag, attributes in HTML_ALLOWED_ATTRIBUTES.items()
+}
+```
+
+NetBox's allow-list keeps `class` on `div`, which is safe for the operator-authored comment fields it was written for. An email body is different. It arrives from a provider and renders inside a page that has already loaded Tabler, so a borrowed utility class such as `position-fixed w-100 h-100` floats the email over the surrounding UI as a clickable overlay. Dropping the attribute costs the email nothing, because mail clients never see this page's stylesheet.
+
+The mapping is derived from NetBox's, so upstream additions to the allow-list carry over.
+
+## Adding your own extension
+
+If you are extending the plugin from another plugin, use NetBox's normal mechanism and import the render helpers if they are useful:
+
+```python
+from netbox.plugins import PluginTemplateExtension
+
+from notices.template_content import render_event_history
+
+
+class TenantEventHistory(PluginTemplateExtension):
+    models = ["tenancy.tenant"]
+
+    def right_page(self):
+        return render_event_history(self.context["object"])
+
+
+template_extensions = [TenantEventHistory]
+```
+
+`render_event_history` returns an empty string when there is nothing to show, so it is safe to call unconditionally.
+
+## See also
+
+- [Configuration](../configuration.md) for `allowed_content_types` and `event_history_days`
+- [Site and Location Resolvers](resolvers.md) for making a new type filterable
+- [Architecture](architecture.md) for the full registry list

--- a/docs/events/dashboard.md
+++ b/docs/events/dashboard.md
@@ -1,0 +1,78 @@
+# Dashboard
+
+The dashboard is the landing page of the plugin, at `/plugins/notices/`, reachable from **Notices > Dashboard > Summary**. It answers the question a NOC asks at the start of a shift: what is happening now, what is coming, and what has nobody looked at yet.
+
+It is a read-only summary. Every figure and row links through to the underlying record or list.
+
+## Access
+
+The whole page requires a single permission, `notices.view_maintenance`. The outage counters are rendered without a separate `notices.view_outage` check, so a user who can see the dashboard sees outage figures whether or not they can open the outage records themselves.
+
+Unlike the model list views, the dashboard does not apply object-level permission filtering. Its queries count every matching row. On a deployment that uses constrained permissions to partition events between teams, the counters are deployment-wide rather than scoped to the viewer.
+
+## What counts as active
+
+Two status groups drive most of the page.
+
+| Group | Statuses |
+|---|---|
+| Active maintenance | `TENTATIVE`, `CONFIRMED`, `IN-PROCESS`, `RE-SCHEDULED` |
+| Active outage | `REPORTED`, `INVESTIGATING`, `IDENTIFIED`, `MONITORING` |
+
+`COMPLETED`, `CANCELLED` and `RESOLVED` are terminal and never counted as active. Note that `RE-SCHEDULED` counts as active: a maintenance that has been superseded still appears in the totals until it is closed out, alongside the replacement that superseded it.
+
+## Statistics
+
+Six counters sit at the top of the page.
+
+| Counter | Query |
+|---|---|
+| Maintenance in progress | Maintenances with status `IN-PROCESS`. No date bound. |
+| Active outages | Outages in any active status. No date bound. |
+| Confirmed this week | Maintenances with status `CONFIRMED` starting between now and seven days from now. |
+| Upcoming (7 days) | Maintenances in any active status starting in the next seven days. |
+| Upcoming (30 days) | Maintenances in any active status starting in the next thirty days. |
+| Unacknowledged | Active maintenances plus active outages where `acknowledged` is false. |
+
+A tile is only rendered when its value is non-zero, so a quiet week shows a shorter page rather than a row of zeros.
+
+Two details are worth knowing when the numbers look wrong. "Confirmed this week" is a subset of "Upcoming (7 days)" rather than a separate group, since `CONFIRMED` is one of the active statuses. And both upcoming counters filter on `start` only, so a long maintenance that began last week and runs through next week is counted in neither.
+
+The unacknowledged counter is the one to watch. `acknowledged` is set from the **Acknowledge** quick action on a maintenance, and nothing sets it automatically, so this figure is the backlog of events that arrived and were never reviewed.
+
+## Timeline
+
+Below the counters is a fourteen-day timeline, built from two queries.
+
+Maintenances appear if they are in an active status, start before the end of the window, and have not already ended. That last condition means the timeline shows events currently in flight, not only those that have yet to begin. Results are ordered by start time and capped at twenty.
+
+Outages appear if they are in an active status, with no date filter at all. An outage that has been open for three months is still shown, which is deliberate: an unresolved outage is current regardless of when it started. Results are ordered by start time and capped at twenty.
+
+Both querysets select the provider and annotate an impact count, so the timeline renders without per-row queries.
+
+The twenty-row cap is fixed and there is no pagination. When either list is truncated the page gives no indication, so treat a timeline holding exactly twenty rows as a prompt to use the [maintenance](maintenance.md) or [outage](outage.md) list views instead.
+
+## Upcoming by provider
+
+The last section groups scheduled work by provider. It selects maintenances with status `TENTATIVE` or `CONFIRMED` starting at any point in the future, ordered by provider name and then start time, capped at fifty.
+
+The status filter here is narrower than the one used for the counters: `IN-PROCESS` and `RE-SCHEDULED` are excluded. The section is about work still to be scheduled around, not work already under way.
+
+There is no end date bound, so this list runs as far into the future as your records go.
+
+## Filtering and export
+
+The dashboard has neither. It runs a fixed set of queries with no query-parameter handling, and offers no CSV or bulk actions.
+
+For anything beyond the summary, use the list views, which carry the full filtersets including the site, region, site group and location filters described in [Impact Tracking](impact.md):
+
+- `/plugins/notices/maintenance/`
+- `/plugins/notices/outages/`
+
+For a calendar rather than a list, see [Calendar and iCal Feed](calendar-and-ical.md). For the same figures on the NetBox home page, add the **Upcoming Maintenance Events** widget described in [Template Extensions](../developer/template-extensions.md).
+
+## See also
+
+- [Maintenance Events](maintenance.md)
+- [Outage Events](outage.md)
+- [Permissions](../permissions.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,1 @@
-{%
-    include-markdown "../README.md"
-%}
+--8<-- "README.md"

--- a/docs/integrations_aws_ses.md
+++ b/docs/integrations_aws_ses.md
@@ -1,5 +1,1 @@
-# AWS SES Integration
-
-{%
-  include-markdown "../integrations/aws-ses/README.md"
-%}
+--8<-- "integrations/aws-ses/README.md"

--- a/docs/messaging/recipient-discovery.md
+++ b/docs/messaging/recipient-discovery.md
@@ -1,0 +1,138 @@
+# Recipient Discovery
+
+Recipient discovery answers one question: given an event and a template, which NetBox contacts should hear about it? The answer is derived from the objects the event impacts, not maintained as a separate mailing list.
+
+The implementation is `notices/services/recipient_discovery.py`.
+
+## The path from event to contact
+
+Discovery walks four hops:
+
+```
+Event  ->  Impact  ->  target.tenant  ->  ContactAssignment  ->  Contact
+```
+
+1. Collect the event's `Impact` records.
+2. For each impact, read `tenant` from the impact's target object.
+3. For each distinct tenant, look up its contact assignments.
+4. Filter those assignments by the template's roles and priorities, and return the contacts.
+
+Every step is a plain traversal of NetBox's own tenancy data. There is no notification-specific recipient list to keep up to date, which is the point: if a circuit is assigned to the right tenant and the tenant has the right contacts, the notification reaches the right people.
+
+The consequence is that **a target with no tenant produces no recipients**. An impact on a device that has never been assigned a tenant contributes nothing to the recipient list and raises no error. This is the usual reason a notification comes out empty.
+
+The tenant is read from the target object itself, not from the event. A maintenance has no tenant of its own; it inherits its audience from what it impacts.
+
+## Roles and priorities
+
+Two fields on the template narrow the contacts pulled from a tenant.
+
+`contact_roles` is a set of `tenancy.ContactRole` objects. When populated, only assignments with one of those roles are considered. When empty, role is not filtered on at all.
+
+`contact_priorities` is a list of priority values, from `primary`, `secondary` and `tertiary`. When populated, only assignments at those priorities are considered. When empty, priority is not filtered on.
+
+Both fields are permissive when empty, which means a template with neither set collects every contact assigned to every affected tenant. Narrowing usually means setting at least a role.
+
+One filter is always applied regardless of configuration: assignments with priority `inactive` are excluded. There is no way to include them.
+
+Contacts are deduplicated by primary key, so a contact assigned to a tenant twice under different roles appears once.
+
+## Granularity
+
+The template's `granularity` decides how the result is grouped, and the return type changes with it.
+
+| Granularity | Return value |
+|---|---|
+| `per_event` | A flat list of `Contact` objects |
+| `per_tenant` | A dict of `{tenant: [Contact, ...]}` |
+| `per_impact` | A dict of `{impact: [Contact, ...]}` |
+
+`per_event` produces one notification for the whole event, addressed to everyone affected. Every tenant sees the full impact list, including impacts belonging to other tenants, so it suits internal distribution rather than customer notices.
+
+`per_tenant` is the default and the usual choice for customer notices. Each tenant gets its own notification, and the `tenant_impacts` context variable is narrowed to that tenant's impacts. See [Templates](templates.md).
+
+`per_impact` produces one notification per impact record. A tenant with six affected circuits receives six notifications. This is for cases where each notice has to name a single service, and it can generate a large volume from one event.
+
+An unrecognised granularity value falls back to `per_event`.
+
+In `per_impact`, an impact whose target has no tenant is still present as a key, mapped to an empty list. In `per_tenant` and `per_event` it is skipped entirely.
+
+## Calling it
+
+The service takes a template and exposes two entry points.
+
+```python
+from notices.services.recipient_discovery import RecipientDiscoveryService
+
+service = RecipientDiscoveryService(template)
+
+service.discover_for_event(maintenance)
+service.discover_for_event(maintenance, granularity="per_event")
+service.discover_for_tenant(tenant)
+```
+
+`discover_for_event()` takes an optional `granularity` argument that overrides the template's own, which is useful for previewing what a different grouping would produce.
+
+`discover_for_tenant()` skips the impact traversal and returns the contacts for one tenant directly. It is the path for standalone notifications, which have no event to walk.
+
+A convenience function wraps both:
+
+```python
+from notices.services.recipient_discovery import discover_recipients
+
+discover_recipients(template, event=maintenance)
+discover_recipients(template, tenant=acme)
+discover_recipients(template, event=maintenance, granularity="per_impact")
+```
+
+`discover_recipients` prefers `event` when both are supplied, and returns an empty list when neither is.
+
+The service reads `contact_roles` and `contact_priorities` once, in its constructor. Changing the template after building a service has no effect on that instance.
+
+## Discovery is not the snapshot
+
+Discovery produces `Contact` objects. It does not decide what a notification is finally sent to.
+
+Contacts are attached to a `PreparedNotification` through its `contacts` M2M. The list of addresses that delivery actually uses is `recipients`, a JSON snapshot taken by the state machine when the notification moves from `draft` to `ready`:
+
+```json
+[
+  {"email": "noc@example.com", "name": "Example NOC", "contact_id": 12}
+]
+```
+
+Two things follow. A contact with no email address is dropped at snapshot time, so it can be attached to a notification and still not receive it. And editing a contact's address after approval does not change where an already-approved notification goes, because the snapshot is what delivery reads. That is deliberate: the record shows where the message was actually addressed.
+
+A notification with an empty snapshot cannot be approved. The transition to `ready` raises a validation error rather than producing a notification with no audience. See [Approval Workflow](workflow.md).
+
+## Troubleshooting an empty list
+
+Work back along the path, in this order:
+
+1. **Does the event have impacts?** No impacts means no targets, so no tenants.
+2. **Do the impact targets have a tenant?** This is the most common cause. Check `impact.target.tenant` for each.
+3. **Does the tenant have contact assignments?** Look at the Contacts panel on the tenant.
+4. **Do the assignments match the template's roles?** An empty `contact_roles` matches everything, so a role set on the template that nobody is assigned under yields nothing.
+5. **Do they match the priorities?** Same logic, and remember that `inactive` is always excluded.
+6. **Do the contacts have email addresses?** They will survive discovery and disappear at snapshot time.
+
+A quick check in `nbshell`:
+
+```python
+from notices.models import Maintenance, NotificationTemplate
+from notices.services.recipient_discovery import discover_recipients
+
+m = Maintenance.objects.get(name="PWIC-12345")
+t = NotificationTemplate.objects.get(slug="customer-maintenance")
+
+for impact in m.impacts.all():
+    print(impact.target, "->", getattr(impact.target, "tenant", None))
+
+discover_recipients(t, event=m)
+```
+
+## See also
+
+- [Templates](templates.md) for `contact_roles`, `contact_priorities` and granularity
+- [Approval Workflow](workflow.md) for the recipient snapshot
+- [Impact Tracking](../events/impact.md) for how impacts are created

--- a/docs/messaging/templates.md
+++ b/docs/messaging/templates.md
@@ -1,0 +1,229 @@
+# Templates
+
+A `NotificationTemplate` is the Jinja source for an outgoing notification, together with the rules that decide when it applies and who it goes to. Templates are managed under **Notices > Messaging > Notification Templates**.
+
+This page covers the model, the rendering context, and how the plugin picks a template out of several candidates. For the states a rendered notification moves through, see [Approval Workflow](workflow.md). For how contacts are found, see [Recipient Discovery](recipient-discovery.md).
+
+## Model
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | CharField (100) | Required. |
+| `slug` | SlugField | Unique. |
+| `description` | TextField | Free text. |
+| `event_type` | CharField (choices) | Which event types this template applies to. |
+| `granularity` | CharField (choices) | How notifications are grouped. Default `per_tenant`. |
+| `subject_template` | TextField | Jinja source for the subject line. Required. |
+| `body_template` | TextField | Jinja source for the body. Required. |
+| `body_format` | CharField (choices) | `markdown` (default), `html` or `text`. |
+| `css_template` | TextField | Styles for HTML output. |
+| `headers_template` | JSONField | Per-header Jinja sources. Accepts YAML on input. |
+| `include_ical` | BooleanField | Generate an iCal attachment. Maintenance only. |
+| `ical_template` | TextField | Jinja source for the iCal body. |
+| `contact_roles` | M2M -> `tenancy.ContactRole` | Roles to include during discovery. |
+| `contact_priorities` | ArrayField | Priorities to include, for example `["primary"]`. |
+| `is_base_template` | BooleanField | Marks a template as extendable. |
+| `extends` | FK -> `NotificationTemplate` | Parent template for Jinja block inheritance. |
+| `weight` | IntegerField | Base matching weight. Default 1000. |
+| `tags` | M2M -> NetBox Tag | Standard tagging. |
+
+### Event type
+
+`event_type` restricts which events a template is a candidate for.
+
+| Value | Meaning |
+|---|---|
+| `maintenance` | Maintenance events only |
+| `outage` | Outage events only |
+| `both` | Either event type |
+| `none` | Standalone notifications with no linked event |
+
+Matching treats `both` as a match for either type. A template with `none` is only ever considered when there is no event in context, so `none` templates and event templates never compete.
+
+### Granularity
+
+`granularity` decides how many notifications one event produces.
+
+| Value | Result |
+|---|---|
+| `per_event` | One notification covering every impact |
+| `per_tenant` | One notification per affected tenant, the default |
+| `per_impact` | One notification per impact record |
+
+Granularity is consumed by recipient discovery, which returns a different shape for each value. See [Recipient Discovery](recipient-discovery.md).
+
+## Rendering context
+
+Templates are rendered by `TemplateRenderer`, whose `build_context()` classmethod assembles the variables. Only the following are provided.
+
+Always present:
+
+| Variable | Value |
+|---|---|
+| `now` | `timezone.now()` at render time |
+| `netbox_url` | Django's `BASE_URL` setting, or an empty string if unset |
+| `tenant` | The target tenant, or `None` |
+| `impacts` | The `Impact` records in scope, or an empty list |
+
+Present only when the notification is linked to an event:
+
+| Variable | Value |
+|---|---|
+| `maintenance` or `outage` | The event, under a key named for its model |
+| `tenant_impacts` | `impacts` narrowed to those whose target belongs to `tenant`. Falls back to the full list when no tenant is given. |
+| `highest_impact` | The worst level across `impacts`, ranked `OUTAGE`, `DEGRADED`, `REDUCED-REDUNDANCY`, `NO-IMPACT`. Only set when `impacts` is non-empty. |
+
+The event key is named after the model, so a maintenance is available as `{{ maintenance }}` and an outage as `{{ outage }}`. There is no generic `event` variable. A template with `event_type = both` has to handle both names:
+
+```jinja
+{% set event = maintenance if maintenance is defined else outage %}
+```
+
+`build_context()` accepts arbitrary keyword arguments and merges them in last, so a caller generating notifications can inject anything else a template needs. iCal rendering uses this to add `message_sequence`, which is therefore available in an `ical_template` but not in a body template. See [Outgoing Notifications](../outgoing-notifications.md).
+
+`netbox_url` is empty unless `BASE_URL` is set in `configuration.py`. Absolute links in a template need it, so set it before relying on them:
+
+```jinja
+View details: {{ netbox_url }}{{ maintenance.get_absolute_url }}
+```
+
+## Syntax and filters
+
+Templates are standard Jinja2. The environment runs with `autoescape=False`, which suits Markdown and plain text bodies but means an HTML template is responsible for escaping anything that could contain markup. Provider-supplied fields such as `summary` and `impact` are the ones to watch.
+
+Two custom filters are registered.
+
+**`ical_datetime`** formats a datetime as `YYYYMMDDTHHMMSSZ` in UTC, which is what iCal expects. Naive datetimes pass through unconverted; `None` renders as an empty string.
+
+```jinja
+DTSTART:{{ maintenance.start|ical_datetime }}
+```
+
+**`markdown`** renders Markdown to HTML with the `tables`, `fenced_code` and `nl2br` extensions enabled.
+
+```jinja
+{{ maintenance.summary|markdown }}
+```
+
+### Example
+
+A subject line:
+
+```jinja
+[{{ maintenance.status }}] {{ maintenance.provider.name }} Maintenance: {{ maintenance.name }}
+```
+
+A Markdown body:
+
+```jinja
+# Scheduled Maintenance
+
+**Provider:** {{ maintenance.provider.name }}
+**Reference:** {{ maintenance.name }}
+**Status:** {{ maintenance.status }}
+**Impact:** {{ highest_impact }}
+
+## Window
+
+- Start: {{ maintenance.start }}
+- End: {{ maintenance.end }}
+{% if maintenance.has_timezone_difference %}
+Times shown in {{ maintenance.original_timezone }}:
+{{ maintenance.get_start_in_original_tz }} to {{ maintenance.get_end_in_original_tz }}
+{% endif %}
+
+## Affected services
+
+{% for impact in tenant_impacts %}
+- {{ impact.target }} ({{ impact.impact }})
+{% endfor %}
+
+{{ maintenance.summary }}
+```
+
+## Headers
+
+`headers_template` is a JSON object whose values are Jinja sources, rendered per notification. The API serializer also accepts a YAML string and converts it, which is easier to write by hand:
+
+```yaml
+X-Event-Reference: "{{ maintenance.name }}"
+X-Event-Status: "{{ maintenance.status }}"
+Reply-To: "noc@example.com"
+```
+
+The rendered result is stored on the `PreparedNotification` and is for the delivery system to apply. The plugin does not send mail, so nothing here is validated as a real mail header.
+
+## Inheritance
+
+A shared layout can live in one template that others extend.
+
+Mark the parent with `is_base_template = True` and point children at it with `extends`. Children then use Jinja block syntax:
+
+```jinja
+{% extends "base" %}
+
+{% block content %}
+Provider {{ maintenance.provider.name }} has scheduled work.
+{% endblock %}
+```
+
+The literal name `base` is what `TemplateRenderer.render_with_inheritance()` registers the parent under by default.
+
+`extends` is a plain FK with `on_delete=SET_NULL` and no cycle check, so a template pointing at itself, or two pointing at each other, is accepted by the model and fails at render time instead.
+
+## Scopes and matching
+
+A `TemplateScope` attaches a template to a NetBox object, in the manner of config contexts. When several templates could apply, scopes decide which wins.
+
+| Field | Notes |
+|---|---|
+| `content_type` | The object type this scope matches. |
+| `object_id` | A specific object, or null to match every object of that type. |
+| `event_type` | Optional filter on event type. |
+| `event_status` | Optional filter on event status, for example `CONFIRMED`. |
+| `weight` | Added to the template's weight on a match. Default 1000. |
+
+Scopes are edited from the parent template's page. A unique constraint on `(template, content_type, object_id, event_type, event_status)` stops the same scope being added twice.
+
+### How a template is chosen
+
+`TemplateMatchingService` takes a context of event, tenant and provider, and works in three steps.
+
+First it selects candidates by event type. An event of a given type pulls templates matching that type or `both`; no event pulls templates with `none`.
+
+Then it scores each candidate. A template with no scopes at all is a global default and always matches, at its own weight. A template with scopes matches only if at least one scope matches, and each matching scope adds its weight to the total.
+
+Finally it sorts by score, highest first. `get_best_template()` returns the top one.
+
+A scope matches when all of its populated filters agree:
+
+- `event_type`, if set, must equal the context event type. A scope set to `both` matches any event but not the no-event case.
+- `event_status`, if set, must equal the event's status. This check is skipped when the context has no status.
+- The object must match. The service resolves the context object for the scope's content type, preferring the explicitly supplied tenant or provider, then falling back to an attribute of the same name on the event. A null `object_id` is a wildcard and matches any object of that type. When no context object can be resolved at all, only a wildcard scope matches.
+
+So a scope on `tenancy.tenant` with no `object_id` matches every tenant, while one naming a specific tenant only matches that one, and both add their weight when they match.
+
+### Merging
+
+`get_merged_config()` folds every matching template into one configuration rather than using only the winner. The rules are per field, applied from highest score to lowest:
+
+| Field | Rule |
+|---|---|
+| `subject_template` | First non-empty wins |
+| `body_template` | First non-empty wins, and carries its `body_format` with it |
+| `css_template` | First non-empty wins |
+| `ical_template` | First non-empty wins |
+| `extends` | First non-null wins |
+| `headers_template` | Merged key by key, the higher-scored value winning per key |
+| `include_ical` | True if true on any matching template |
+| `contact_roles` | Union across all matching templates |
+| `contact_priorities` | Union across all matching templates |
+
+The two union fields are the ones that surprise people. A low-weight global template that adds a role or priority widens the recipient list for every notification, because the union is taken across everything that matched rather than only the winner.
+
+## See also
+
+- [Recipient Discovery](recipient-discovery.md)
+- [Approval Workflow](workflow.md)
+- [Outgoing Notifications](../outgoing-notifications.md) for the overall architecture
+- [REST API](../api/rest-api.md) for the template and notification endpoints

--- a/docs/messaging/workflow.md
+++ b/docs/messaging/workflow.md
@@ -1,0 +1,179 @@
+# Approval Workflow
+
+A `PreparedNotification` is a rendered notification with a status. The status moves through a state machine that validates every transition and applies side effects, so the record shows not just what was sent but when it was approved, by whom, and when it was accepted for delivery.
+
+The implementation is `PreparedNotificationStateMachine` in `notices/validators.py`.
+
+## States
+
+| Status | Meaning |
+|---|---|
+| `draft` | Rendered but not approved. Content and recipients are still editable. |
+| `ready` | Approved and queued. Recipients are frozen. |
+| `sent` | Handed to the delivery system. |
+| `delivered` | Confirmed as delivered. Terminal. |
+| `failed` | Delivery failed. Can be retried. |
+
+## Transitions
+
+```
+draft --> ready --> sent --> delivered
+            ^         |
+            |         v
+            +------ failed
+```
+
+| From | Allowed targets |
+|---|---|
+| `draft` | `ready` |
+| `ready` | `sent` |
+| `sent` | `delivered`, `failed` |
+| `delivered` | none |
+| `failed` | `ready` |
+
+Anything else is rejected with the current status and the valid targets named in the error.
+
+Three properties of this graph matter in practice.
+
+There is no route back from `ready` to `draft`. Approval is one-way. A notification approved by mistake cannot be edited back into a draft; it has to be left unsent or deleted.
+
+`delivered` is terminal, and `failed` returns to `ready` rather than to `sent`. A retry goes through approval again, which re-snapshots recipients and re-stamps the approval fields, so a retry after a contact was corrected picks up the new address.
+
+There is no `cancelled` state. A notification that should not go out is deleted, not withdrawn.
+
+## Side effects
+
+Each transition does more than write a status.
+
+**To `ready`.** The recipient snapshot is recomputed from the `contacts` M2M, keeping only contacts with an email address. If the resulting snapshot is empty, the transition is refused:
+
+```
+Cannot approve notification with no recipients. Add contacts first.
+```
+
+Then `approved_by` is set to the requesting user and `approved_at` to the current time. Because this runs on every entry to `ready`, a retry from `failed` re-snapshots and re-stamps rather than preserving the original approval.
+
+**To `sent`.** `sent_at` is set, but only if it is not already set. A second transition into `sent` cannot happen anyway, given the transition table.
+
+**To `delivered`.** `delivered_at` is set on the same terms.
+
+**To `failed`.** No side effects. Nothing records why it failed except the journal entry, if one is supplied.
+
+The whole transition runs in a database transaction, so a refused approval leaves no partial snapshot behind.
+
+## Timestamps
+
+By default a transition stamps the current time. A delivery system that batches, or polls on a delay, can supply the real time instead:
+
+```json
+{"status": "sent", "timestamp": "2026-08-31T14:32:00Z"}
+```
+
+Two rules are enforced:
+
+- A timestamp cannot be in the future.
+- Ordering has to hold. `sent_at` cannot precede `approved_at`, and `delivered_at` cannot precede `sent_at`.
+
+A violation is returned as a validation error against the `timestamp` field.
+
+The ordering checks compare against the stored value, so they only apply when the earlier stamp exists. `approved_at` is always set by the transition into `ready`, so in normal use both checks are live.
+
+One asymmetry is worth knowing: `approved_at` is always the real current time and ignores a supplied `timestamp`. Only `sent_at` and `delivered_at` honour it.
+
+## Journal entries
+
+Any transition can carry a `message`, which creates a NetBox journal entry against the notification recording the status change and the message text. The entry's kind is derived from the target status:
+
+| Target status | Journal kind |
+|---|---|
+| `ready` | info |
+| `sent` | info |
+| `delivered` | success |
+| `failed` | warning |
+
+No message means no journal entry. Nothing else is written, so a `failed` transition with no message leaves no record of the reason. A delivery system should always send one on failure.
+
+## Driving it over the API
+
+Status is changed through the REST API only. The field is deliberately absent from the web UI, and the bulk edit view for prepared notifications is unmounted, because a direct write would bypass the recipient snapshot and the approval stamps described above. See [Permissions](../permissions.md).
+
+### Create as draft
+
+A create is always `draft`. Posting any other status is refused:
+
+```
+A notification is always created as 'draft'. Create it first, then PATCH it to 'ready'.
+```
+
+The reason is that a create has no prior state, so the state machine never runs. A notification stored straight into `ready` would carry no recipient snapshot and no approval stamps, and since `ready` has no route back to `draft`, nothing downstream could repair it. Before this was enforced, such a record would be retried by the outbound poller indefinitely.
+
+```http
+POST /api/plugins/notices/prepared-notifications/
+```
+
+```json
+{
+  "template_id": 3,
+  "event_content_type": 91,
+  "event_id": 42,
+  "subject": "Scheduled maintenance on your circuit",
+  "body_text": "...",
+  "contact_ids": [12, 15]
+}
+```
+
+### Approve
+
+```http
+PATCH /api/plugins/notices/prepared-notifications/57/
+```
+
+```json
+{"status": "ready", "message": "Reviewed by NOC shift lead"}
+```
+
+### Mark sent and delivered
+
+```json
+{"status": "sent", "timestamp": "2026-08-31T14:32:00Z"}
+```
+
+```json
+{"status": "delivered", "timestamp": "2026-08-31T14:32:07Z"}
+```
+
+### Record a failure
+
+```json
+{"status": "failed", "message": "SMTP 550: mailbox unavailable"}
+```
+
+## A delivery loop
+
+The plugin is the queue; the delivery system is the worker. A polling loop looks like this:
+
+1. `GET /api/plugins/notices/prepared-notifications/?status=ready` for work.
+2. Send each notification using its `subject`, `body_text`, `body_html`, `headers`, `css` and `ical_content`, addressed to the entries in `recipients`.
+3. `PATCH` each to `sent` with the send time.
+4. `PATCH` to `delivered` on confirmation, or to `failed` with a message.
+
+Read `recipients`, not `contacts`. The snapshot is the frozen list of addresses taken at approval; the M2M is the live set of contact records and may have moved since. See [Recipient Discovery](recipient-discovery.md).
+
+Once a notification reaches `sent` or `delivered` it also appears in the read-only sent notifications list and its own API endpoint:
+
+```http
+GET /api/plugins/notices/sent-notifications/
+```
+
+That endpoint is a proxy over the same table, filtered to `sent` and `delivered` and restricted to `GET`, `HEAD` and `OPTIONS`.
+
+## Fields the state machine does not set
+
+`viewed_at` exists on the model and appears on the detail page, but no code path writes it. It is read-only in both serializers and has no transition attached, so it stays empty. Treat it as reserved.
+
+## See also
+
+- [Templates](templates.md)
+- [Recipient Discovery](recipient-discovery.md)
+- [REST API](../api/rest-api.md)
+- [Permissions](../permissions.md)

--- a/docs/outgoing-notifications.md
+++ b/docs/outgoing-notifications.md
@@ -1,762 +1,187 @@
 # Outgoing Notifications
 
-This document describes the outgoing notification system in netbox-notices for composing and preparing messages based on maintenance and outage events.
+Event tracking is inbound: a provider tells you about a maintenance window. Outgoing notifications are the other direction, where you tell your own customers about it.
 
-## Overview
+The plugin composes those notifications and tracks their lifecycle. It does not deliver them. Composition, recipient discovery and state tracking live here; SMTP, Slack, Teams and webhooks live in an external delivery system that talks to the REST API.
 
-The outgoing notifications feature provides a complete message composition system that:
+This page is the overview. The details are on their own pages:
 
-- **Composes messages** from Jinja2 templates with full access to event and impact data
-- **Discovers recipients** automatically from NetBox contacts via tenant relationships
-- **Generates iCal attachments** for maintenance events following the BCOP standard
-- **Tracks message lifecycle** from draft through delivery with full audit trail
+- [Templates](messaging/templates.md) covers the `NotificationTemplate` model, the Jinja context, and how a template is matched and merged.
+- [Recipient Discovery](messaging/recipient-discovery.md) covers how contacts are found from impacted objects.
+- [Approval Workflow](messaging/workflow.md) covers the state machine and the delivery loop.
 
-This is a **content/delivery separation** architecture:
-
-- **This plugin handles:** Templates, recipient discovery, message composition, and state tracking
-- **External systems handle:** Actual delivery (SMTP, Slack, Teams, webhooks, etc.)
-
-## Architecture
+## Flow
 
 ```
-                                    ┌─────────────────────┐
-                                    │   Maintenance or    │
-                                    │   Outage Event      │
-                                    └──────────┬──────────┘
-                                               │
-                    ┌──────────────────────────┼──────────────────────────┐
-                    │                          │                          │
-                    ▼                          ▼                          ▼
-           ┌────────────────┐        ┌────────────────┐        ┌────────────────┐
-           │ MessageTemplate│        │  TemplateScope │        │   Contacts     │
-           │   (Jinja2)     │◄───────│   (Matching)   │        │  (Recipients)  │
-           └────────┬───────┘        └────────────────┘        └────────┬───────┘
-                    │                                                   │
-                    └──────────────────┬────────────────────────────────┘
-                                       │
-                                       ▼
-                              ┌────────────────┐
-                              │PreparedMessage │
-                              │  (Rendered)    │
-                              └────────┬───────┘
-                                       │
-                                       ▼
-                              ┌────────────────┐
-                              │   REST API     │
-                              │ (Pull Model)   │
-                              └────────┬───────┘
-                                       │
-                                       ▼
-                              ┌────────────────┐
-                              │ External       │
-                              │ Delivery       │
-                              │ System         │
-                              └────────────────┘
+   Maintenance or Outage
+            |
+            v
+   +--------------------+     scopes decide which template applies
+   | NotificationTemplate | <-- TemplateScope (weighted, config-context style)
+   +--------------------+
+            |
+            | render subject, body, headers, CSS, iCal
+            | discover recipients from impacts -> tenants -> contacts
+            v
+   +----------------------+
+   | PreparedNotification |  status: draft
+   +----------------------+
+            |
+            | PATCH status=ready  (snapshots recipients, stamps approval)
+            v
+        REST API  <----  external delivery system polls for status=ready
+            |
+            | PATCH status=sent, then delivered or failed
+            v
+   +----------------------+
+   |  SentNotification    |  read-only proxy over sent and delivered
+   +----------------------+
 ```
 
 ## Models
 
-### MessageTemplate
+| Model | Purpose |
+|---|---|
+| `NotificationTemplate` | Jinja sources plus matching and recipient configuration |
+| `TemplateScope` | Attaches a template to a NetBox object with a weight |
+| `PreparedNotification` | A rendered notification with a status and a recipient snapshot |
+| `SentNotification` | Proxy over `PreparedNotification`, filtered to `sent` and `delivered` |
 
-A Jinja template for generating outgoing notifications. Templates can be scoped to specific objects (tenants, providers, sites, etc.) via TemplateScope assignments, similar to Config Contexts.
+Field-by-field reference is in [Templates](messaging/templates.md) and [Approval Workflow](messaging/workflow.md).
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `name` | CharField | Human-readable template name |
-| `slug` | SlugField | URL-safe identifier (unique) |
-| `description` | TextField | Optional description |
-| `event_type` | CharField | Which events this applies to: `maintenance`, `outage`, `both`, or `none` |
-| `granularity` | CharField | Message grouping: `per_event`, `per_tenant`, or `per_impact` |
-| `subject_template` | TextField | Jinja template for email subject |
-| `body_template` | TextField | Jinja template for message body |
-| `body_format` | CharField | Output format: `markdown`, `html`, or `text` |
-| `css_template` | TextField | CSS styles for HTML output |
-| `headers_template` | JSONField | Email headers as Jinja templates |
-| `include_ical` | BooleanField | Generate iCal attachment (Maintenance only) |
-| `ical_template` | TextField | Jinja template for iCal content |
-| `contact_roles` | M2M | Contact roles to include in recipient discovery |
-| `contact_priorities` | ArrayField | Contact priorities: `primary`, `secondary`, `tertiary` |
-| `is_base_template` | BooleanField | Whether this can be extended by other templates |
-| `extends` | ForeignKey | Parent template for Jinja block inheritance |
-| `weight` | IntegerField | Base weight for template matching (higher wins) |
+The rendered content is a snapshot. Editing a template afterwards does not change notifications already prepared from it, and editing a contact does not change the `recipients` list of a notification already approved. That is what makes the sent log an audit record rather than a live view.
 
-### TemplateScope
+## iCal attachments
 
-Links a MessageTemplate to NetBox objects for Config Context-like matching. When generating messages, templates with matching scopes are selected and merged by weight.
+A maintenance notification can carry an iCal attachment following the BCOP Maintnote standard, so a recipient's calendar client shows the window.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `template` | ForeignKey | Parent MessageTemplate |
-| `content_type` | ForeignKey | Type of object (e.g., Tenant, Provider, Site) |
-| `object_id` | BigIntegerField | Specific object ID, or null for all of that type |
-| `event_type` | CharField | Filter by event type (optional) |
-| `event_status` | CharField | Filter by event status (optional) |
-| `weight` | IntegerField | Weight for merge priority (higher wins) |
+`ICalGenerationService` generates one only when all three of these hold:
 
-### PreparedMessage
+1. The event is a `Maintenance`, not an `Outage`.
+2. The template has `include_ical` set.
+3. The template has a non-empty `ical_template`.
 
-A rendered message ready for delivery. Stores a snapshot of rendered content and recipients at generation time. Status transitions are validated via state machine.
+`generate_ical()` returns `None` rather than raising when the conditions are not met.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `template` | ForeignKey | Source MessageTemplate |
-| `event_content_type` | ForeignKey | Type of linked event (optional) |
-| `event_id` | BigIntegerField | ID of linked event (optional) |
-| `status` | CharField | Current status: `draft`, `ready`, `sent`, `delivered`, `failed` |
-| `contacts` | M2M | Contacts to receive this message |
-| `recipients` | JSONField | Snapshot of recipients at approval time (read-only) |
-| `subject` | CharField | Rendered subject line |
-| `body_text` | TextField | Rendered plain text body |
-| `body_html` | TextField | Rendered HTML body |
-| `headers` | JSONField | Rendered email headers |
-| `css` | TextField | Rendered CSS |
-| `ical_content` | TextField | Rendered iCal attachment |
-| `approved_by` | ForeignKey | User who approved the message |
-| `approved_at` | DateTimeField | When the message was approved |
-| `sent_at` | DateTimeField | When the message was sent |
-| `delivered_at` | DateTimeField | When delivery was confirmed |
-| `viewed_at` | DateTimeField | When the message was viewed |
+### BCOP properties
 
-## Template Creation
+| Property | Source |
+|---|---|
+| `X-MAINTNOTE-PROVIDER` | Provider slug |
+| `X-MAINTNOTE-ACCOUNT` | Tenant name |
+| `X-MAINTNOTE-MAINTENANCE-ID` | Maintenance `name`, with `X-MAINTNOTE-PRECEDENCE=PRIMARY` |
+| `X-MAINTNOTE-OBJECT-ID` | One line per impact, using the circuit ID where the target has one |
+| `X-MAINTNOTE-IMPACT` | Worst impact level across the impacts in scope |
+| `X-MAINTNOTE-STATUS` | Event status |
 
-### Event Type Targeting
+### Context
 
-The `event_type` field determines which events a template can be used with:
+The iCal template sees the same variables as the body template, plus `message_sequence`, which maps to the iCal `SEQUENCE` property and lets a calendar client recognise an update to an event it already holds. `message_sequence` is passed by the caller and defaults to 1; it is not available in body templates.
 
-| Value | Description |
-|-------|-------------|
-| `maintenance` | Only for Maintenance events |
-| `outage` | Only for Outage events |
-| `both` | For both Maintenance and Outage events |
-| `none` | Standalone messages not linked to events |
+`highest_impact` is guaranteed here, defaulting to `NO-IMPACT` when there are no impacts, whereas in a body template it is only present when impacts exist.
 
-### Granularity
+### Reference template
 
-The `granularity` field controls how messages are grouped when generated from events:
-
-| Value | Description |
-|-------|-------------|
-| `per_event` | One message for the entire event (all impacts in one message) |
-| `per_tenant` | One message per affected tenant (group impacts by tenant) |
-| `per_impact` | One message per impact record (individual notifications) |
-
-### Template Syntax
-
-Templates use Jinja2 syntax with full support for:
-
-- Variable interpolation: `{{ maintenance.name }}`
-- Conditionals: `{% if maintenance.status == 'CONFIRMED' %}...{% endif %}`
-- Loops: `{% for impact in impacts %}...{% endfor %}`
-- Filters: `{{ maintenance.start|ical_datetime }}`
-- Block inheritance: `{% extends "base" %}{% block content %}...{% endblock %}`
-
-**Example subject template:**
-
-```jinja
-[{{ maintenance.status }}] {{ maintenance.provider.name }} Maintenance: {{ maintenance.name }}
-```
-
-**Example body template:**
-
-```jinja
-# Maintenance Notification
-
-**Provider:** {{ maintenance.provider.name }}
-**Maintenance ID:** {{ maintenance.name }}
-**Status:** {{ maintenance.status }}
-
-## Schedule
-
-- **Start:** {{ maintenance.start }}
-- **End:** {{ maintenance.end }}
-
-## Affected Services
-
-{% for impact in tenant_impacts %}
-- {{ impact.target }} ({{ impact.impact }})
-{% endfor %}
-
-## Summary
-
-{{ maintenance.summary }}
-
----
-This is an automated notification from NetBox.
-View details: {{ netbox_url }}{{ maintenance.get_absolute_url }}
-```
-
-### Context Variables
-
-#### All Templates
-
-| Variable | Description |
-|----------|-------------|
-| `now` | Current datetime |
-| `netbox_url` | NetBox base URL |
-| `tenant` | Target tenant (when using per_tenant granularity) |
-| `impacts` | All Impact records for this message scope |
-| `contacts` | List of recipient Contact objects |
-
-#### Maintenance Event-Linked
-
-| Variable | Description |
-|----------|-------------|
-| `maintenance` | The Maintenance object |
-| `maintenance.provider` | Provider object |
-| `maintenance.status` | Current status (TENTATIVE, CONFIRMED, etc.) |
-| `maintenance.start` | Scheduled start time |
-| `maintenance.end` | Scheduled end time |
-| `maintenance.summary` | Maintenance summary text |
-| `tenant_impacts` | Impacts filtered for current tenant |
-| `highest_impact` | Worst impact level (OUTAGE > DEGRADED > REDUCED-REDUNDANCY > NO-IMPACT) |
-| `message_sequence` | Notification count for this tenant+event |
-
-#### Outage Event-Linked
-
-| Variable | Description |
-|----------|-------------|
-| `outage` | The Outage object |
-| `outage.reported_at` | When the outage was reported |
-| `outage.estimated_time_to_repair` | ETR if known |
-| `outage.status` | Current status (REPORTED, INVESTIGATING, etc.) |
-| `outage.end` | Resolution time (if resolved) |
-
-#### Per-Impact Granularity
-
-| Variable | Description |
-|----------|-------------|
-| `impact` | The specific Impact record |
-| `impact.target` | The impacted object |
-| `object` | Alias for `impact.target` |
-
-### Custom Filters
-
-#### ical_datetime
-
-Formats a datetime as an iCal-compliant datetime string (YYYYMMDDTHHMMSSZ in UTC).
-
-```jinja
-DTSTART:{{ maintenance.start|ical_datetime }}
-```
-
-Output: `DTSTART:20260122T143000Z`
-
-#### markdown
-
-Renders Markdown text to HTML. Supports tables, fenced code blocks, and line breaks.
-
-```jinja
-{{ maintenance.summary|markdown }}
-```
-
-## Recipient Discovery
-
-Recipients are discovered automatically from NetBox contacts based on the template configuration:
-
-### Flow
-
-1. **Collect target objects** from event impacts based on granularity
-2. **Resolve tenants** from impacted objects via `object.tenant`
-3. **Find contacts** by querying ContactAssignments where:
-   - Role is in template's `contact_roles`
-   - Priority is in template's `contact_priorities`
-   - Priority is not `inactive`
-4. **Populate PreparedMessage** with discovered contacts
-5. **Snapshot recipients** when message transitions to `ready` status
-
-### Example
-
-A maintenance event impacts two circuits:
-
-- Circuit A belongs to Tenant X
-- Circuit B belongs to Tenant Y
-
-With `granularity=per_tenant` and `contact_roles=[NOC]`:
-
-1. System creates two PreparedMessages (one per tenant)
-2. For Tenant X's message, discovers contacts with NOC role assigned to Tenant X
-3. For Tenant Y's message, discovers contacts with NOC role assigned to Tenant Y
-
-### Standalone Messages
-
-For templates with `event_type=none`:
-
-- No automatic recipient discovery
-- User manually selects contacts while in `draft` status
-- Same approval and delivery flow applies
-
-## Template Matching
-
-When generating messages from an event, templates are matched and merged based on scopes.
-
-### Matching Algorithm
-
-1. **Filter by event type:**
-   - Maintenance events match templates where `event_type` is `maintenance` or `both`
-   - Outage events match templates where `event_type` is `outage` or `both`
-
-2. **Score templates by scope matches:**
-   ```
-   score = template.weight
-   for each scope in template.scopes:
-       if scope matches context:
-           score += scope.weight
-   ```
-
-3. **Select templates:**
-   - Include templates with at least one matching scope
-   - Include templates with no scopes (global defaults)
-
-### Scope Matching
-
-A scope matches when:
-
-- Its `content_type` matches an object in the context (tenant, provider, etc.)
-- Its `object_id` is null (matches all of that type) OR matches the specific object
-- Its `event_type` is null OR matches the current event type
-- Its `event_status` is null OR matches the current event status
-
-### Field-Level Merging
-
-When multiple templates match, fields are merged by weight (higher wins):
-
-- `subject_template`
-- `body_template`
-- `headers_template`
-- `css_template`
-- `ical_template`
-
-If a higher-weighted template's field is empty/null, the value is inherited from lower-weighted templates.
-
-## iCal Generation
-
-### When Generated
-
-iCal attachments are generated when:
-
-1. Template has `include_ical=True`
-2. Message is linked to a Maintenance event (not Outage)
-3. Template has a non-empty `ical_template`
-
-### BCOP Standard
-
-The iCal format follows the [BCOP (Best Current Operational Practice) standard](https://github.com/mjethanandani/circuit-maintenance) for circuit maintenance notifications.
-
-### Required X-MAINTNOTE-* Properties
-
-| Property | Description |
-|----------|-------------|
-| `X-MAINTNOTE-PROVIDER` | Service provider identifier (e.g., provider slug) |
-| `X-MAINTNOTE-ACCOUNT` | Customer account identifier (e.g., tenant name) |
-| `X-MAINTNOTE-MAINTENANCE-ID` | Unique maintenance identifier |
-| `X-MAINTNOTE-OBJECT-ID` | Affected service/circuit ID(s) |
-| `X-MAINTNOTE-IMPACT` | Impact level: NO-IMPACT, REDUCED-REDUNDANCY, DEGRADED, OUTAGE |
-| `X-MAINTNOTE-STATUS` | Status: TENTATIVE, CONFIRMED, CANCELLED, IN-PROCESS, COMPLETED |
-
-### Example BCOP Template
-
-```ical
-BEGIN:VCALENDAR
-VERSION:2.0
-PRODID:-//YourCompany//netbox-notices//EN
-METHOD:REQUEST
-BEGIN:VEVENT
-DTSTAMP:{{ now|ical_datetime }}
-DTSTART:{{ maintenance.start|ical_datetime }}
-DTEND:{{ maintenance.end|ical_datetime }}
-UID:{{ maintenance.pk }}-{{ tenant.pk }}@yourcompany.com
-SUMMARY:{{ maintenance.name }} - {{ maintenance.provider.name }}
-DESCRIPTION:{{ maintenance.summary | replace('\n', '\\n') }}
-ORGANIZER;CN="{{ maintenance.provider.name }}":mailto:noc@yourcompany.com
-SEQUENCE:{{ message_sequence|default(0) }}
-X-MAINTNOTE-PROVIDER:{{ maintenance.provider.slug }}
-X-MAINTNOTE-ACCOUNT:{{ tenant.name }}
-X-MAINTNOTE-MAINTENANCE-ID;X-MAINTNOTE-PRECEDENCE=PRIMARY:{{ maintenance.name }}
-{% for impact in tenant_impacts %}
-X-MAINTNOTE-OBJECT-ID:{{ impact.target }}
-{% endfor %}
-X-MAINTNOTE-IMPACT:{{ highest_impact }}
-X-MAINTNOTE-STATUS:{{ maintenance.status }}
-END:VEVENT
-END:VCALENDAR
-```
-
-## State Machine
-
-PreparedMessage status transitions are enforced by a state machine with validation.
-
-### Status Workflow
-
-```
-         ┌─────────────────────────────────┐
-         │                                 │
-         ▼                                 │
-      [draft] ──────> [ready] ──────> [sent] ──────> [delivered]
-         │               │                │
-         │               │                │
-         ▼               │                ▼
-      (delete)           │            [failed]
-                         │                │
-                         │                │
-                         └────────────────┘
-                              (retry)
-```
-
-### Valid Transitions
-
-| From | To | Trigger |
-|------|----|---------|
-| `draft` | `ready` | Approve message |
-| `draft` | (delete) | Delete draft |
-| `ready` | `sent` | External system picks up message |
-| `sent` | `delivered` | Delivery confirmed |
-| `sent` | `failed` | Delivery failed |
-| `failed` | `ready` | Retry delivery |
-
-### Validation Requirements
-
-**draft -> ready (approval):**
-
-- `recipients` must not be empty (computed from `contacts`)
-- Sets `approved_by` to current user
-- Sets `approved_at` to current timestamp
-- Snapshots recipients JSON from contacts
-
-**ready -> sent:**
-
-- Sets `sent_at` to provided `timestamp` or current time
-
-**sent -> delivered:**
-
-- Sets `delivered_at` to provided `timestamp` or current time
-
-### Optional Timestamp Parameter
-
-External delivery systems may process messages in batches or have delayed polling. The `timestamp` parameter allows specifying when a transition actually occurred:
-
-```http
-PATCH /api/plugins/notices/prepared-messages/1/
-{
-    "status": "sent",
-    "timestamp": "2026-01-27T10:00:00Z",
-    "message": "Sent via batch processor"
-}
-```
-
-**Timestamp validation:**
-
-- Cannot be in the future
-- Must respect chronological order:
-  - `sent_at` >= `approved_at`
-  - `delivered_at` >= `sent_at`
-
-If `timestamp` is not provided, the current time is used.
-
-## REST API
-
-### Endpoints
-
-```
-GET    /api/plugins/notices/message-templates/
-POST   /api/plugins/notices/message-templates/
-GET    /api/plugins/notices/message-templates/{id}/
-PUT    /api/plugins/notices/message-templates/{id}/
-PATCH  /api/plugins/notices/message-templates/{id}/
-DELETE /api/plugins/notices/message-templates/{id}/
-
-GET    /api/plugins/notices/prepared-messages/
-POST   /api/plugins/notices/prepared-messages/
-GET    /api/plugins/notices/prepared-messages/{id}/
-PATCH  /api/plugins/notices/prepared-messages/{id}/
-DELETE /api/plugins/notices/prepared-messages/{id}/
-```
-
-### Filtering PreparedMessages
-
-Query messages by status for delivery system integration:
-
-```http
-GET /api/plugins/notices/prepared-messages/?status=ready
-```
-
-### Creating a MessageTemplate
-
-```http
-POST /api/plugins/notices/message-templates/
-Content-Type: application/json
-Authorization: Token YOUR_API_TOKEN
-
-{
-    "name": "Maintenance Notification",
-    "slug": "maintenance-notification",
-    "event_type": "maintenance",
-    "granularity": "per_tenant",
-    "subject_template": "[{{ maintenance.status }}] {{ maintenance.provider.name }}: {{ maintenance.name }}",
-    "body_template": "# Maintenance Notice\n\n{{ maintenance.summary }}",
-    "body_format": "markdown",
-    "include_ical": true,
-    "ical_template": "BEGIN:VCALENDAR\n...\nEND:VCALENDAR",
-    "contact_priorities": ["primary", "secondary"],
-    "weight": 1000
-}
-```
-
-**Response:**
-
-```json
-{
-    "id": 1,
-    "url": "/api/plugins/notices/message-templates/1/",
-    "display": "Maintenance Notification",
-    "name": "Maintenance Notification",
-    "slug": "maintenance-notification",
-    "event_type": "maintenance",
-    "granularity": "per_tenant",
-    ...
-}
-```
-
-### Creating a PreparedMessage
-
-```http
-POST /api/plugins/notices/prepared-messages/
-Content-Type: application/json
-Authorization: Token YOUR_API_TOKEN
-
-{
-    "template_id": 1,
-    "event_content_type": "maintenance",
-    "event_id": 42,
-    "subject": "Scheduled Maintenance: MAINT-001",
-    "body_text": "This is a test notification...",
-    "contact_ids": [1, 2, 3]
-}
-```
-
-### Updating Message Status
-
-External delivery systems update status after processing:
-
-**Mark as sent:**
-
-```http
-PATCH /api/plugins/notices/prepared-messages/1/
-Content-Type: application/json
-Authorization: Token YOUR_API_TOKEN
-
-{
-    "status": "sent",
-    "message": "Sent via SMTP relay"
-}
-```
-
-**Mark as sent with custom timestamp (for batch processing):**
-
-```http
-PATCH /api/plugins/notices/prepared-messages/1/
-Content-Type: application/json
-Authorization: Token YOUR_API_TOKEN
-
-{
-    "status": "sent",
-    "timestamp": "2026-01-22T10:30:00Z",
-    "message": "Sent via batch processor"
-}
-```
-
-**Mark as delivered:**
-
-```http
-PATCH /api/plugins/notices/prepared-messages/1/
-Content-Type: application/json
-Authorization: Token YOUR_API_TOKEN
-
-{
-    "status": "delivered",
-    "timestamp": "2026-01-22T10:31:00Z",
-    "message": "Delivered to 5 recipients"
-}
-```
-
-**Mark as failed (for retry):**
-
-```http
-PATCH /api/plugins/notices/prepared-messages/1/
-Content-Type: application/json
-Authorization: Token YOUR_API_TOKEN
-
-{
-    "status": "failed",
-    "message": "SMTP connection refused"
-}
-```
-
-### Journal Entries
-
-When a `message` field is included in status updates, a journal entry is automatically created:
-
-| New Status | Journal Kind |
-|------------|--------------|
-| `ready` | info |
-| `sent` | info |
-| `delivered` | success |
-| `failed` | warning |
-
-## Integration
-
-### Pull-Based API Model
-
-The recommended integration pattern is pull-based:
-
-1. External delivery system polls for ready messages:
-   ```http
-   GET /api/plugins/notices/prepared-messages/?status=ready
-   ```
-
-2. For each message, the delivery system:
-   - Extracts recipient emails from `recipients` array
-   - Sends the message via appropriate channel (email, Slack, etc.)
-   - Updates status to `sent`
-   - Updates status to `delivered` or `failed` based on result
-
-### Webhook Integration
-
-For push-based delivery, use NetBox's built-in Event Rules:
-
-1. Go to **Operations > Event Rules**
-2. Create a rule for `PreparedMessage` object type
-3. Set condition: status = "ready"
-4. Configure webhook URL for your delivery system
-
-When a PreparedMessage transitions to `ready` status, NetBox will POST the message data to your webhook endpoint.
-
-### Example Delivery Script
+`notices.services.ical_generation.DEFAULT_BCOP_ICAL_TEMPLATE` holds a working template you can copy into a new one as a starting point:
 
 ```python
-#!/usr/bin/env python3
-"""Example script to deliver prepared messages via SMTP."""
+from notices.services.ical_generation import DEFAULT_BCOP_ICAL_TEMPLATE
 
-import requests
+print(DEFAULT_BCOP_ICAL_TEMPLATE)
+```
+
+## Integrating a delivery system
+
+The plugin is the queue and the delivery system is the worker. Poll for approved notifications, send them, and report back:
+
+1. `GET /api/plugins/notices/prepared-notifications/?status=ready`
+2. Send each one, addressed to the entries in `recipients`.
+3. `PATCH` it to `sent`, including a `timestamp` if you are reporting after the fact.
+4. `PATCH` it to `delivered` on confirmation, or to `failed` with a `message`.
+
+Two things are easy to get wrong.
+
+Address from `recipients`, not `contacts`. The former is the frozen snapshot taken at approval; the latter is the live set of contact records.
+
+Follow the transition graph. `ready` goes to `sent`, and only `sent` goes to `delivered`. Attempting to jump from `ready` straight to `delivered` is rejected. See [Approval Workflow](messaging/workflow.md).
+
+### Minimal SMTP loop
+
+```python
 import smtplib
 from datetime import datetime, timezone
 from email.message import EmailMessage
+
+import requests
 
 NETBOX_URL = "https://netbox.example.com"
 API_TOKEN = "your-api-token"
 SMTP_HOST = "smtp.example.com"
 
 headers = {"Authorization": f"Token {API_TOKEN}"}
+endpoint = f"{NETBOX_URL}/api/plugins/notices/prepared-notifications/"
 
-# Fetch ready messages
-response = requests.get(
-    f"{NETBOX_URL}/api/plugins/notices/prepared-messages/",
-    params={"status": "ready"},
-    headers=headers,
-)
-messages = response.json()["results"]
+response = requests.get(endpoint, params={"status": "ready"}, headers=headers)
 
-for msg in messages:
+for notification in response.json()["results"]:
     try:
-        # Build email
         email = EmailMessage()
-        email["Subject"] = msg["subject"]
+        email["Subject"] = notification["subject"]
         email["From"] = "noc@example.com"
-        email["To"] = ", ".join(r["email"] for r in msg["recipients"])
-        email.set_content(msg["body_text"])
+        email["To"] = ", ".join(r["email"] for r in notification["recipients"])
+        email.set_content(notification["body_text"])
 
-        if msg["body_html"]:
-            email.add_alternative(msg["body_html"], subtype="html")
+        if notification["body_html"]:
+            email.add_alternative(notification["body_html"], subtype="html")
 
-        if msg["ical_content"]:
+        if notification["ical_content"]:
             email.add_attachment(
-                msg["ical_content"].encode(),
+                notification["ical_content"].encode(),
                 maintype="text",
                 subtype="calendar",
                 filename="maintenance.ics",
             )
 
-        # Record send time before sending
         sent_at = datetime.now(timezone.utc).isoformat()
-
-        # Send email
         with smtplib.SMTP(SMTP_HOST) as smtp:
             smtp.send_message(email)
 
-        # Update status to sent with timestamp
         requests.patch(
-            f"{NETBOX_URL}/api/plugins/notices/prepared-messages/{msg['id']}/",
+            f"{endpoint}{notification['id']}/",
             json={"status": "sent", "timestamp": sent_at, "message": "Sent via SMTP"},
             headers=headers,
         )
-
-        # Update status to delivered
-        delivered_at = datetime.now(timezone.utc).isoformat()
         requests.patch(
-            f"{NETBOX_URL}/api/plugins/notices/prepared-messages/{msg['id']}/",
+            f"{endpoint}{notification['id']}/",
             json={
                 "status": "delivered",
-                "timestamp": delivered_at,
-                "message": f"Delivered to {len(msg['recipients'])} recipients",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "message": f"Delivered to {len(notification['recipients'])} recipients",
             },
             headers=headers,
         )
-
-    except Exception as e:
-        # Mark as failed
+    except Exception as exc:
         requests.patch(
-            f"{NETBOX_URL}/api/plugins/notices/prepared-messages/{msg['id']}/",
-            json={"status": "failed", "message": str(e)},
+            f"{endpoint}{notification['id']}/",
+            json={"status": "failed", "message": str(exc)},
             headers=headers,
         )
 ```
 
-### Slack Integration Example
+Marking `delivered` immediately after a successful SMTP handoff is a simplification. SMTP acceptance is not delivery; a real integration leaves the notification at `sent` and moves it to `delivered` when the transport reports back.
 
-```python
-"""Example: Post prepared messages to Slack."""
+### Push instead of polling
 
-import requests
+For push-based delivery, use NetBox event rules under **Operations > Event Rules**. Create a rule on the `PreparedNotification` object type conditioned on `status = ready` and point it at your delivery system's webhook. The status updates still go back through the REST API.
 
-NETBOX_URL = "https://netbox.example.com"
-API_TOKEN = "your-netbox-token"
-SLACK_WEBHOOK = "https://hooks.slack.com/services/..."
+### AWS SES
 
-headers = {"Authorization": f"Token {API_TOKEN}"}
+For a deployable integration with full delivery lifecycle tracking, including bounce and complaint handling and open and click events, see the [AWS SES Integration](integrations_aws_ses.md) guide. It covers scheduled polling, MIME construction with HTML and iCal parts, an SES configuration set with SNS event destinations, automatic status updates driven by SES events, and journal entries for informational events.
 
-response = requests.get(
-    f"{NETBOX_URL}/api/plugins/notices/prepared-messages/",
-    params={"status": "ready"},
-    headers=headers,
-)
+## See also
 
-for msg in response.json()["results"]:
-    # Post to Slack
-    slack_payload = {
-        "text": msg["subject"],
-        "blocks": [
-            {"type": "header", "text": {"type": "plain_text", "text": msg["subject"]}},
-            {"type": "section", "text": {"type": "mrkdwn", "text": msg["body_text"][:3000]}},
-        ],
-    }
-
-    result = requests.post(SLACK_WEBHOOK, json=slack_payload)
-
-    if result.ok:
-        requests.patch(
-            f"{NETBOX_URL}/api/plugins/notices/prepared-messages/{msg['id']}/",
-            json={"status": "delivered", "message": "Posted to Slack"},
-            headers=headers,
-        )
-```
-
-### AWS SES Integration
-
-For a complete, deployable AWS SES integration that handles outbound delivery with full delivery lifecycle tracking (delivery confirmation, bounce/complaint handling, open/click tracking), see the [AWS SES Integration](integrations_aws_ses.md) guide.
-
-The SES integration provides:
-
-- Scheduled polling for ready notifications
-- MIME email construction with HTML, plain text, and iCal attachments
-- SES Configuration Set with SNS event destinations for tracking
-- Automatic status updates (sent, delivered, failed) based on SES events
-- Journal entries for informational events (open, click, delivery delay)
+- [Templates](messaging/templates.md)
+- [Recipient Discovery](messaging/recipient-discovery.md)
+- [Approval Workflow](messaging/workflow.md)
+- [REST API](api/rest-api.md)
+- [Permissions](permissions.md)

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -44,6 +44,41 @@ nav = [
   { "Changelog" = "changelog.md" },
 ]
 
+# Zensical replaces its built-in extension defaults wholesale when this table
+# is present, so the stock set is restated here alongside pymdownx.snippets.
+# Dropping an entry below removes that extension from the build.
+[project.markdown_extensions]
+abbr = {}
+admonition = {}
+attr_list = {}
+def_list = {}
+footnotes = {}
+md_in_html = {}
+toc = { permalink = true }
+
+[project.markdown_extensions.pymdownx]
+arithmatex = { generic = true }
+betterem = {}
+caret = {}
+details = {}
+emoji = { emoji_generator = "zensical.extensions.emoji.to_svg", emoji_index = "zensical.extensions.emoji.twemoji" }
+highlight = { anchor_linenums = true, line_spans = "__span", pygments_lang_class = true }
+inlinehilite = {}
+keys = {}
+magiclink = {}
+mark = {}
+smartsymbols = {}
+superfences = { custom_fences = [ { name = "mermaid", class = "mermaid" } ] }
+tabbed = { alternate_style = true, combine_header_slug = true }
+tasklist = { custom_checkbox = true }
+tilde = {}
+
+# Pulls README.md, CHANGELOG.md, CONTRIBUTING.md and the AWS SES README into
+# the site; base_path is the repo root, one level above docs_dir.
+[project.markdown_extensions.pymdownx.snippets]
+base_path = [".."]
+check_paths = true
+
 [project.theme]
 features = [
   "content.action.edit",


### PR DESCRIPTION
## Summary

- The published docs site was broken in two independent ways: four pages rendered a raw `{% include-markdown %}` macro instead of their content, and eight pages the nav links to were never written, so the sidebar shipped 404s.
- Fixes both, writes the eight missing pages against the source, and reduces `outgoing-notifications.md` to the overview its nav position calls for.
- Also corrects three README links that were already broken on PyPI.

## Background

`{% include-markdown %}` is `mkdocs-include-markdown-plugin` syntax. That plugin was never carried over when the site moved to Zensical, so the macro published as literal text on the home page, changelog, contributing and AWS SES pages. Zensical ships `pymdownx.snippets` via `pymdown-extensions`, which is the supported equivalent.

Separately, `zensical.toml` listed eight nav targets with no file behind them. Zensical does not fail a build on those; it emits the target verbatim, so the sidebar carried hrefs ending in `.md`. Six in-body links pointed into the same missing pages.

## Changes

- `docs/zensical.toml`: enable `pymdownx.snippets` with the repo root as base path. Declaring `markdown_extensions` replaces Zensical's defaults wholesale rather than merging, so the stock set is restated alongside it; a comment in the file records that.
- `docs/{index,changelog,contributing,integrations_aws_ses}.md`: `--8<--` in place of the macro.
- `README.md`: six screenshots and the permissions link were repo-relative. Snippets does not rewrite relative URLs, and PyPI never resolved them either, so they are absolute now.
- `.github/workflows/docs.yml`: the path filter was `docs/**` only, so a README or CHANGELOG edit would not have republished the site that now embeds them.
- `docs/api/rest-api.md`: the seven endpoints, fields, filters, generic-FK writes, prepared-notification status rules, iCal feed, GraphQL.
- `docs/developer/architecture.md`: module map, model layer, the registries the plugin populates, signals, services.
- `docs/developer/resolvers.md`: the resolver registry, built-ins, the signal obligation that comes with registering one, `refresh_impact_sites`.
- `docs/developer/template-extensions.md`: the runtime-generated extension classes, the provider panel, the dashboard widget, `sanitize_html`.
- `docs/messaging/templates.md`: model, the context `build_context()` actually provides, filters, inheritance, scope scoring and merge rules.
- `docs/messaging/recipient-discovery.md`: the event to impact to tenant to contact path, granularity return shapes, and why the list comes back empty.
- `docs/messaging/workflow.md`: state graph, per-transition side effects, timestamp ordering, the delivery loop.
- `docs/events/dashboard.md`: the six counters, the timeline and its row caps.
- `docs/outgoing-notifications.md`: rewritten as an overview. It duplicated the three new messaging pages and was wrong in copy-pasteable ways -- see #63.
- `.gitignore`: `/site` is root-anchored and left over from mkdocs; Zensical builds into `docs/site`.

## Defects found while reading the source

Documented as they behave, not as intended, and filed rather than fixed here:

- #61 -- `MaintenanceSerializer` and `OutageSerializer` always return `null` for `impacts` and `notifications`. Both declare a `source` that does not resolve against a `GenericRelation`, and DRF returns `None` instead of raising. Verified against a record with one impact: `impacts` is `null` while `impact_count` is `1`.
- #62 -- `PreparedNotification.viewed_at` is on the model, in both serializers and on the detail template, but no code path writes it.
- #63 -- the errors in `outgoing-notifications.md`, fixed by this PR.

## Testing

- [x] `zensical build` passes with no issues (was 6 warnings before)
- [x] No `.md` hrefs left in the rendered nav
- [x] All four previously-broken pages render their included source
- [x] README images and permissions link resolve in the built site
- [x] ASCII-only across every added and modified file
- [ ] `pytest` -- not run; no Python changed
- [ ] Migration applied -- n/a

## Related

Refs: #61, #62
Fixes: #63
