### PR TITLE
chore: add NetBox 4.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
           - "4.5.10"
           # renovate: datasource=github-releases depName=netbox-community/netbox
           - "4.6.10"
+          # renovate: datasource=github-releases depName=netbox-community/netbox
+          - "4.7.0"
     services:
       postgres:
         image: postgres:18-alpine
@@ -157,7 +159,7 @@ jobs:
           pytest tests/ -v --tb=short --cov=notices --cov-report=xml
 
       - name: Upload coverage to Codecov
-        if: matrix.python == '3.13' && startsWith(matrix.netbox, '4.6.')
+        if: matrix.python == '3.13' && startsWith(matrix.netbox, '4.7.')
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Releases prior to v1.1.x use the legacy `## VERSION (DATE)` heading style.
 
 ## [Unreleased]
 
+### Added
+
+- NetBox 4.7 support: CI now tests against NetBox 4.7.0 alongside 4.5.x and
+  4.6.x, and the README compatibility matrix lists the new series.
+
 ### Fixed
 
 - The documentation site rendered `{% include-markdown "../README.md" %}` as

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This plugin requires NetBox 4.5.0 or higher.
 | -------------- | -------------- |
 | 4.5.x          | 1.x            |
 | 4.6.x          | 1.x            |
+| 4.7.x          | 1.x            |
 
 ## Installing
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@ This page covers installing and enabling the `netbox-notices` plugin in an exist
 
 | Component | Required version |
 |-----------|------------------|
-| NetBox | 4.5.0 or later (CI covers 4.5.x and 4.6.x) |
+| NetBox | 4.5.0 or later (CI covers 4.5.x, 4.6.x, and 4.7.x) |
 | Python | 3.12, 3.13, or 3.14 |
 | PostgreSQL | Whatever your NetBox version requires |
 

--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,12 @@
       "matchPackageNames": ["netbox-community/netbox"],
       "matchCurrentValue": "/^4\\.6\\./",
       "allowedVersions": "/^4\\.6\\./"
+    },
+    {
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["netbox-community/netbox"],
+      "matchCurrentValue": "/^4\\.7\\./",
+      "allowedVersions": "/^4\\.7\\./"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Summary
- Adds NetBox 4.7.0 to the CI test matrix (keeping 4.5.10 and 4.6.10) and moves the Codecov upload from the 4.6 lane to the 4.7 lane.
- Adds the Renovate per-minor lane so the 4.7 entry stays pinned to the newest 4.7.x release.
- Declares NetBox 4.7 support in the CHANGELOG, README compatibility matrix, and docs/installation.md.

The 4.7 compatibility review found no code changes required: the plugin never sends mail through Django (the 4.7 MAILERS rework cannot affect it), uses no removed APIs, and has no version cap.

## Changes
- .github/workflows/ci.yml: renovate-annotated 4.7.0 matrix entry; codecov condition anchored to startsWith '4.7.'
- renovate.json: allowedVersions lane for /^4\.7\./
- CHANGELOG.md: Unreleased entry declaring 4.7 support
- README.md, docs/installation.md: compatibility rows for 4.7.x

## Testing
- [x] Workflow YAML and renovate.json parse cleanly
- [ ] `ruff check` / `ruff format --check` -- not applicable (no Python touched)
- [ ] Full suite on 4.7 -- left to this PR's CI run (new 4.7.0 lane)

## Related
Closes #66
