### PR TITLE
fix(ical): compute feed validators from everything rendered into the body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,21 @@ Releases prior to v1.1.x use the legacy `## VERSION (DATE)` heading style.
   and weak (`W/"..."`), comma-listed and `*` forms match. Tags cached before
   the upgrade no longer match, so each ETag-only client re-downloads the feed
   once and then revalidates normally.
+- The iCal feed's `Last-Modified` could move backwards when a maintenance was
+  deleted or aged out of the `past_days` window, pinning date-revalidating
+  clients on `304` while the deleted event stayed on their calendars. The
+  validator now also considers the latest logged deletion of a maintenance or
+  impact and the latest window exit, so it never regresses when the feed body
+  changed ([#70](https://github.com/jsenecal/netbox-notices/issues/70)).
+- One maintenance row with a NULL `last_updated` (fixture loads, restores,
+  raw SQL) blanked the feed's `Last-Modified` and froze the `ETag`'s modified
+  component. The validator now aggregates with `Max`, which ignores NULLs
+  ([#71](https://github.com/jsenecal/netbox-notices/issues/71)).
+- Impact and provider changes are rendered into the feed body (`DESCRIPTION`,
+  `LOCATION`) but moved neither validator, so revalidating clients received
+  `304` for a changed feed. Both validators now cover the matching
+  maintenances' impacts and providers, and the `ETag` additionally hashes the
+  impact count ([#73](https://github.com/jsenecal/netbox-notices/issues/73)).
 
 - The documentation site rendered `{% include-markdown "../README.md" %}` as
   literal text on the home page, changelog, contributing and AWS SES pages.

--- a/docs/events/calendar-and-ical.md
+++ b/docs/events/calendar-and-ical.md
@@ -87,10 +87,10 @@ Most clients refresh on their own schedule (Google: every few hours; Apple: conf
 
 ### Caching and conditional requests
 
-The view computes a deterministic ETag from `(query parameters, latest last_updated, count)` of the matching queryset. The response always includes:
+The view computes a deterministic ETag from the query parameters, the feed's last-modified instant (below), and the maintenance and impact counts of the matching queryset. The response always includes:
 
 - `ETag: "<md5 hex>"` -- conditional request validator, quoted per RFC 9110.
-- `Last-Modified: <RFC 1123 date>` -- the most recent `last_updated` of any matching maintenance.
+- `Last-Modified: <RFC 1123 date>` -- the latest instant the feed body could have changed: the most recent `last_updated` across the matching maintenances, their impacts and their providers, the most recent logged deletion of a maintenance or impact, or the most recent moment an event aged out of the `past_days` window.
 - `Cache-Control: public, max-age=<ical_cache_max_age>` -- only on subscription mode (not when `download=true`).
 
 Conditional requests are evaluated with Django's `get_conditional_response`, which follows RFC 9110. Every `304 Not Modified` repeats the headers above with no body:

--- a/notices/ical_utils.py
+++ b/notices/ical_utils.py
@@ -2,8 +2,13 @@
 
 import hashlib
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
+from core.choices import ObjectChangeActionChoices
+from core.models import ObjectChange
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Max
+from django.utils import timezone
 from icalendar import Calendar, Event
 
 
@@ -33,7 +38,7 @@ def get_ical_status(maintenance_status):
     return status_map.get(maintenance_status, "TENTATIVE")
 
 
-def calculate_etag(count, latest_modified, params):
+def calculate_etag(count, latest_modified, params, impact_count=0):
     """
     Calculate ETag for cache validation.
 
@@ -41,6 +46,9 @@ def calculate_etag(count, latest_modified, params):
         count: Number of maintenances in queryset
         latest_modified: Most recent last_updated datetime
         params: Dictionary of query parameters
+        impact_count: Number of impacts on those maintenances -- impacts are
+            rendered into the feed body, so adding or removing one must change
+            the tag even when no maintenance row moved
 
     Returns:
         MD5 hash string for ETag header
@@ -52,10 +60,77 @@ def calculate_etag(count, latest_modified, params):
     modified_str = latest_modified.isoformat() if latest_modified else "none"
 
     # Combine all components
-    etag_source = f"{params_str}-{modified_str}-{count}"
+    etag_source = f"{params_str}-{modified_str}-{count}-{impact_count}"
 
     # Generate MD5 hash
     return hashlib.md5(etag_source.encode()).hexdigest()
+
+
+def maintenance_window_cutoff(past_days):
+    """
+    The instant separating in-window from aged-out maintenances.
+
+    Single source of the past_days membership rule: the feed queryset keeps
+    events with start at or after this instant, and feed_last_modified treats
+    everything before it as having exited the window.
+    """
+    return timezone.now() - timedelta(days=past_days)
+
+
+def feed_last_modified(queryset, past_days):
+    """
+    Latest instant at which the feed body could have changed.
+
+    A maintenance row's own last_updated is not enough: the feed also renders
+    each event's impacts (DESCRIPTION) and provider (LOCATION), rows leave the
+    feed when deleted, and rows age out of the past_days window with no data
+    change at all. Each of those moments contributes a candidate here so the
+    advertised Last-Modified never moves backwards when the body changed:
+
+    - the matching maintenances', their impacts', and their providers'
+      last_updated;
+    - the latest logged deletion of a Maintenance or Impact (any deletion, not
+      just ones matching this feed's filters: one spurious full download beats
+      indefinite staleness, and the changelog does not record enough to scope
+      it);
+    - the latest window exit -- an event with start S leaves the feed at
+      S + past_days, so the most recent exit is max(start) over the already
+      excluded rows plus the window.
+
+    Args:
+        queryset: The filtered Maintenance queryset backing the feed
+        past_days: The feed's window size in days
+
+    Returns:
+        An aware datetime, or None when nothing has ever been in the feed
+    """
+    from .models import Impact, Maintenance
+
+    candidates = [
+        value
+        for value in queryset.aggregate(
+            Max("last_updated"),
+            Max("impacts__last_updated"),
+            Max("provider__last_updated"),
+        ).values()
+        if value is not None
+    ]
+
+    content_types = ContentType.objects.get_for_models(Maintenance, Impact).values()
+    latest_delete = ObjectChange.objects.filter(
+        changed_object_type__in=list(content_types),
+        action=ObjectChangeActionChoices.ACTION_DELETE,
+    ).aggregate(Max("time"))["time__max"]
+    if latest_delete is not None:
+        candidates.append(latest_delete)
+
+    latest_excluded_start = Maintenance.objects.filter(start__lt=maintenance_window_cutoff(past_days)).aggregate(
+        Max("start")
+    )["start__max"]
+    if latest_excluded_start is not None:
+        candidates.append(latest_excluded_start + timedelta(days=past_days))
+
+    return max(candidates) if candidates else None
 
 
 def generate_maintenance_ical(maintenances, request):

--- a/notices/views.py
+++ b/notices/views.py
@@ -30,7 +30,7 @@ from rest_framework import exceptions
 from utilities.views import register_model_view
 
 from . import filtersets, forms, models, tables
-from .ical_utils import calculate_etag, generate_maintenance_ical
+from .ical_utils import calculate_etag, feed_last_modified, generate_maintenance_ical, maintenance_window_cutoff
 from .models import Maintenance, NotificationTemplate, Outage, PreparedNotification, SentNotification, TemplateScope
 from .timeline_utils import build_timeline_item, get_timeline_changes
 
@@ -574,9 +574,10 @@ class MaintenanceICalView(View):
 
         # Get cache-related info
         count = queryset.count()
-        latest_modified = queryset.order_by("-last_updated").values_list("last_updated", flat=True).first()
+        impact_count = queryset.aggregate(impacts=Count("impacts"))["impacts"] or 0
+        latest_modified = feed_last_modified(queryset, params["past_days"])
 
-        etag = calculate_etag(count=count, latest_modified=latest_modified, params=params)
+        etag = calculate_etag(count=count, latest_modified=latest_modified, params=params, impact_count=impact_count)
 
         # Build the response's headers before its body: the conditional check below
         # needs the validators, and a 304 has to echo them back.
@@ -729,8 +730,7 @@ class MaintenanceICalView(View):
     def _build_queryset(self, params):
         """Build filtered Maintenance queryset."""
         # Base queryset with time filter
-        cutoff_date = timezone.now() - timedelta(days=params["past_days"])
-        queryset = models.Maintenance.objects.filter(start__gte=cutoff_date)
+        queryset = models.Maintenance.objects.filter(start__gte=maintenance_window_cutoff(params["past_days"]))
 
         # Optimize queries
         queryset = queryset.select_related("provider").prefetch_related("impacts")

--- a/tests/test_ical_utils.py
+++ b/tests/test_ical_utils.py
@@ -1,16 +1,22 @@
 """Tests for iCal utility functions."""
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
 
 import pytest
 from circuits.models import Circuit, CircuitType, Provider
+from core.choices import ObjectChangeActionChoices
+from core.models import ObjectChange
 from django.contrib.contenttypes.models import ContentType
 from django.test import RequestFactory
+from django.utils import timezone as django_timezone
 
 from notices.ical_utils import (
     calculate_etag,
+    feed_last_modified,
     generate_maintenance_ical,
     get_ical_status,
+    maintenance_window_cutoff,
 )
 from notices.models import Impact, Maintenance
 
@@ -78,6 +84,112 @@ class TestETagCalculation:
         etag1 = calculate_etag(count=5, latest_modified=dt, params=params)
         etag2 = calculate_etag(count=5, latest_modified=dt, params=params)
         assert etag1 == etag2
+
+    def test_etag_includes_impact_count(self):
+        """Adding or removing an impact must change the tag even when nothing else moved."""
+        etag1 = calculate_etag(count=5, latest_modified=None, params={}, impact_count=0)
+        etag2 = calculate_etag(count=5, latest_modified=None, params={}, impact_count=2)
+        assert etag1 != etag2
+
+
+@pytest.mark.django_db
+class TestFeedLastModified:
+    """The validator source must cover everything rendered into the feed body."""
+
+    PAST_DAYS = 30
+
+    @staticmethod
+    def _backdate(instance, **fields):
+        # update() bypasses auto_now/auto_now_add, so timestamps land exactly
+        # where the test needs them instead of at now().
+        type(instance).objects.filter(pk=instance.pk).update(**fields)
+
+    def _maintenance(self, provider, start, last_updated, name="M1"):
+        maintenance = Maintenance.objects.create(
+            name=name,
+            summary="Test",
+            provider=provider,
+            start=start,
+            end=start + timedelta(hours=2),
+            status="CONFIRMED",
+        )
+        self._backdate(maintenance, last_updated=last_updated)
+        return maintenance
+
+    def _backdate_provider(self, provider, when):
+        self._backdate(provider, last_updated=when)
+
+    def _queryset(self):
+        return Maintenance.objects.filter(start__gte=maintenance_window_cutoff(self.PAST_DAYS))
+
+    def test_latest_maintenance_update_wins(self, provider):
+        now = django_timezone.now()
+        self._backdate_provider(provider, now - timedelta(days=10))
+        self._maintenance(provider, now - timedelta(days=1), now - timedelta(days=5), name="M1")
+        self._maintenance(provider, now - timedelta(days=1), now - timedelta(days=3), name="M2")
+
+        assert feed_last_modified(self._queryset(), self.PAST_DAYS) == now - timedelta(days=3)
+
+    def test_null_last_updated_is_ignored(self, provider):
+        """One NULL row must not blank the whole validator (issue #71)."""
+        now = django_timezone.now()
+        self._backdate_provider(provider, now - timedelta(days=10))
+        self._maintenance(provider, now - timedelta(days=1), now - timedelta(days=5), name="M1")
+        self._maintenance(provider, now - timedelta(days=1), None, name="M2")
+
+        assert feed_last_modified(self._queryset(), self.PAST_DAYS) == now - timedelta(days=5)
+
+    def test_impact_update_advances(self, provider):
+        """An impact edit is rendered into DESCRIPTION, so it must move the validator (issue #73)."""
+        now = django_timezone.now()
+        self._backdate_provider(provider, now - timedelta(days=10))
+        maintenance = self._maintenance(provider, now - timedelta(days=1), now - timedelta(days=5))
+
+        impact = Impact.objects.create(event=maintenance, target=provider, impact="OUTAGE")
+        self._backdate(impact, last_updated=now - timedelta(days=2))
+
+        assert feed_last_modified(self._queryset(), self.PAST_DAYS) == now - timedelta(days=2)
+
+    def test_provider_update_advances(self, provider):
+        """A provider rename is rendered into LOCATION, so it must move the validator (issue #73)."""
+        now = django_timezone.now()
+        self._maintenance(provider, now - timedelta(days=1), now - timedelta(days=5))
+        self._backdate_provider(provider, now - timedelta(days=2))
+
+        assert feed_last_modified(self._queryset(), self.PAST_DAYS) == now - timedelta(days=2)
+
+    def test_deletion_advances(self, provider):
+        """A deletion shrinks the queryset, so the delete changelog must move the validator (issue #70)."""
+        now = django_timezone.now()
+        self._backdate_provider(provider, now - timedelta(days=10))
+        self._maintenance(provider, now - timedelta(days=1), now - timedelta(days=5))
+
+        change = ObjectChange.objects.create(
+            user_name="test",
+            request_id=uuid4(),
+            action=ObjectChangeActionChoices.ACTION_DELETE,
+            changed_object_type=ContentType.objects.get_for_model(Maintenance),
+            changed_object_id=9999,
+            object_repr="M-deleted",
+        )
+        self._backdate(change, time=now - timedelta(days=2))
+
+        assert feed_last_modified(self._queryset(), self.PAST_DAYS) == now - timedelta(days=2)
+
+    def test_window_exit_advances(self, provider):
+        """An event leaving the past_days window changes the body at start + past_days (issue #70)."""
+        now = django_timezone.now()
+        self._backdate_provider(provider, now - timedelta(days=10))
+        self._maintenance(provider, now - timedelta(days=1), now - timedelta(days=5), name="M-in")
+        excluded = self._maintenance(
+            provider, now - timedelta(days=self.PAST_DAYS + 1), now - timedelta(days=10), name="M-out"
+        )
+
+        expected = excluded.start + timedelta(days=self.PAST_DAYS)
+        assert feed_last_modified(self._queryset(), self.PAST_DAYS) == expected
+
+    def test_empty_feed_returns_none(self):
+        assert feed_last_modified(self._queryset(), self.PAST_DAYS) is None
 
 
 @pytest.mark.django_db

--- a/tests/test_ical_view.py
+++ b/tests/test_ical_view.py
@@ -287,6 +287,21 @@ class TestMaintenanceICalViewCaching:
         assert response["ETag"].startswith('"')
         assert response["ETag"].endswith('"')
 
+    def test_added_impact_invalidates_revalidation(self, maintenance):
+        """An impact is rendered into the feed, so adding one must break the 304 (issue #73)."""
+        from notices.models import Impact
+
+        response1 = self.client.get(f"/plugins/notices/ical/maintenances.ics?token={self.token.plaintext}")
+
+        Impact.objects.create(event=maintenance, target=maintenance.provider, impact="OUTAGE")
+
+        response2 = self.client.get(
+            f"/plugins/notices/ical/maintenances.ics?token={self.token.plaintext}",
+            HTTP_IF_NONE_MATCH=response1["ETag"],
+        )
+
+        assert response2.status_code == 200
+
     def test_empty_queryset_returns_valid_calendar(self):
         response = self.client.get(f"/plugins/notices/ical/maintenances.ics?token={self.token.plaintext}")
 


### PR DESCRIPTION
## Summary
- The iCal feed's ETag and Last-Modified were computed from the matching
  maintenances' max `last_updated` and row count alone, which returned wrong
  `304 Not Modified` answers in three ways (#70, #71, #73).
- A new `feed_last_modified()` helper aggregates every instant the feed body
  could have changed; the ETag additionally hashes the impact count.

## Changes
- `notices/ical_utils.py`: new `feed_last_modified()` (maintenance/impact/
  provider `last_updated` in one aggregate, delete-changelog watermark,
  window-exit instant) and `maintenance_window_cutoff()` as the single source
  of the `past_days` membership rule; `calculate_etag()` gains `impact_count`.
- `notices/views.py`: the feed view uses both helpers.
- `tests/test_ical_utils.py`: unit tests for every validator input, including
  the NULL `last_updated` row, the deletion watermark, and window-exit math.
- `tests/test_ical_view.py`: HTTP regression -- adding an impact must break
  the 304.
- `CHANGELOG.md`, `docs/events/calendar-and-ical.md`: validator semantics
  documented.

## Testing
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest` passes locally (805 tests)
- [x] New/changed behavior covered by tests (diff coverage 100%)
- [ ] Migration applied cleanly (no schema change)
- [x] Docs updated (README n/a, CHANGELOG, zensical pages)

## Related
Fixes #70
Fixes #71
Fixes #73
